### PR TITLE
Small additions to documentation and typo fixes + slight backup snackbar modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 **Mealie** is a self hosted recipe manager and meal planner with a RestAPI backend and a reactive frontend application built in Vue for a pleasant user experience for the whole family. Easily add recipes into your database by providing the url and mealie will automatically import the relavent data or add a family recipe with the UI editor.  
 
-Mealie also provides a secure API for interactions from 3rd party applications. **Why does my recipe manager need an API?** An API allows integration into applications like [Home Assistant]() that can act as notification engines to provide custom notifications based of Meal Plan data to remind you to defrost the chicken, marinade the steak, or start the CrockPot. See the section on [Meal Plan hooks](#hooks) for more information. Additionally, you can access any avaiable API from the backend server. To explore the API spin up your server and navigate to http://yourserver.com/docs for interactive API documentation. 
+Mealie also provides a secure API for interactions from 3rd party applications. **Why does my recipe manager need an API?** An API allows integration into applications like [Home Assistant]() that can act as notification engines to provide custom notifications based of Meal Plan data to remind you to defrost the chicken, marinade the steak, or start the CrockPot. See the section on [Meal Plan hooks](#hooks) for more information. Additionally, you can access any available API from the backend server. To explore the API spin up your server and navigate to http://yourserver.com/docs for interactive API documentation. 
 
 
 

--- a/docs/docs/1.3 - admin-panel.md
+++ b/docs/docs/1.3 - admin-panel.md
@@ -15,7 +15,7 @@ Color themes can be created and set from the UI in the settings page. You can se
 ## Backup and Export
 All recipe data can be imported and exported as necessary from the UI. Under the admin page you'll find the section for using Backups and Exports. 
 
-To create an export simple add the tag and the markdown template and click Backup Recipes and your backup will be created on the server. The backup is a standard zipfile containing all the images, json files, and rendered markdown files for each recipe. Markdown files are rendered from jinja2 templates. Adding your own markdown file into the templates folder will automatically show up as an option to select when creating a backup. 
+To create an export simple add the tag and the markdown template and click Backup Recipes and your backup will be created on the server. The backup is a standard zipfile containing all the images, json files, and rendered markdown files for each recipe. Markdown files are rendered from jinja2 templates. Adding your own markdown file into the templates folder will automatically show up as an option to select when creating a backup. To view the availible variables, open a recipe in the json editor.
 
 To import a backup it must be in your backups folder. If it is in the backup folder it will automatically show up as an source to restore from. Selected the desired backup and import the backup file. 
 

--- a/frontend/src/api/backup.js
+++ b/frontend/src/api/backup.js
@@ -6,7 +6,7 @@ const backupBase = baseURL + "backups/";
 
 const backupURLs = {
   // Backup
-  avaiable: `${backupBase}avaiable/`,
+  available: `${backupBase}available/`,
   createBackup: `${backupBase}export/database/`,
   importBackup: (fileName) => `${backupBase}${fileName}/import/`,
   deleteBackup: (fileName) => `${backupBase}${fileName}/delete/`,
@@ -14,7 +14,7 @@ const backupURLs = {
 
 export default {
   async requestAvailable() {
-    let response = await apiReq.get(backupURLs.avaiable);
+    let response = await apiReq.get(backupURLs.available);
     return response.data;
   },
 

--- a/frontend/src/components/Admin/Theme.vue
+++ b/frontend/src/components/Admin/Theme.vue
@@ -21,7 +21,7 @@
           <v-form ref="form" lazy-validation>
             <v-select
               label="Saved Color Schemes"
-              :items="avaiableThemes"
+              :items="availableThemes"
               item-text="name"
               item-value="colors"
               return-object
@@ -95,13 +95,13 @@ export default {
       themes: null,
       activeTheme: {},
       darkMode: false,
-      avaiableThemes: [],
+      availableThemes: [],
       selectedScheme: "",
       selectedLight: "",
     };
   },
   async mounted() {
-    this.avaiableThemes = await api.themes.requestAll();
+    this.availableThemes = await api.themes.requestAll();
     this.darkMode = this.$store.getters.getDarkMode;
     this.themes = this.$store.getters.getThemes;
     this.setThemeEditor();
@@ -115,12 +115,12 @@ export default {
         } else if (this.selectedScheme !== "") {
           api.themes.delete(this.selectedScheme.name);
         }
-        this.avaiableThemes = await api.themes.requestAll();
+        this.availableThemes = await api.themes.requestAll();
       }
     },
     async appendTheme(newTheme) {
       api.themes.create(newTheme);
-      this.avaiableThemes.push(newTheme);
+      this.availableThemes.push(newTheme);
     },
     themeSelected() {
       this.activeTheme = this.selectedScheme.colors;

--- a/frontend/src/components/MealPlan/MealSelect.vue
+++ b/frontend/src/components/MealPlan/MealSelect.vue
@@ -5,7 +5,7 @@
         <v-card-title class="headline"> Choose a Recipe </v-card-title>
         <v-card-text>
           <v-autocomplete
-            :items="avaiableRecipes"
+            :items="availableRecipes"
             v-model="selected"
             clearable
             return
@@ -85,7 +85,7 @@ export default {
   },
 
   computed: {
-    avaiableRecipes() {
+    availableRecipes() {
       return this.$store.getters.getRecentRecipes;
     },
   },

--- a/mealie/routes/backup_routes.py
+++ b/mealie/routes/backup_routes.py
@@ -7,8 +7,8 @@ from utils.snackbar import SnackResponse
 router = APIRouter()
 
 
-@router.get("/api/backups/avaiable/", tags=["Import / Export"])
-async def avaiable_imports():
+@router.get("/api/backups/available/", tags=["Import / Export"])
+async def available_imports():
     """ Returns this weeks meal plan """
     imports = []
     templates = []

--- a/mealie/routes/backup_routes.py
+++ b/mealie/routes/backup_routes.py
@@ -26,14 +26,14 @@ async def export_database(data: BackupJob):
     """ Returns this weeks meal plan """
 
     try:
-        export_db(data.tag, data.template)
+        export_path = export_db(data.tag, data.template)
     except:
         HTTPException(
             status_code=400,
             detail=SnackResponse.error("Error Creating Backup. See Log File"),
         )
 
-    return SnackResponse.success("Backup Created in /data/backups")
+    return SnackResponse.success("Backup Created at " + export_path)
 
 
 @router.post(

--- a/mealie/routes/backup_routes.py
+++ b/mealie/routes/backup_routes.py
@@ -9,7 +9,6 @@ router = APIRouter()
 
 @router.get("/api/backups/available/", tags=["Import / Export"])
 async def available_imports():
-    """ Returns this weeks meal plan """
     imports = []
     templates = []
     for archive in BACKUP_DIR.glob("*.zip"):
@@ -23,7 +22,6 @@ async def available_imports():
 
 @router.post("/api/backups/export/database/", tags=["Import / Export"], status_code=201)
 async def export_database(data: BackupJob):
-    """ Returns this weeks meal plan """
 
     try:
         export_path = export_db(data.tag, data.template)
@@ -40,7 +38,6 @@ async def export_database(data: BackupJob):
     "/api/backups/{file_name}/import/", tags=["Import / Export"], status_code=200
 )
 async def import_database(file_name: str):
-    """ Returns this weeks meal plan """
     imported = import_from_archive(file_name)
     return imported
 
@@ -51,7 +48,6 @@ async def import_database(file_name: str):
     status_code=200,
 )
 async def delete_backup(backup_name: str):
-    """ Returns this weeks meal plan """
 
     try:
         BACKUP_DIR.joinpath(backup_name).unlink()

--- a/mealie/routes/meal_routes.py
+++ b/mealie/routes/meal_routes.py
@@ -9,7 +9,7 @@ router = APIRouter()
 
 @router.get("/api/meal-plan/all/", tags=["Meal Plan"])
 async def get_all_meals():
-    """ Returns a list of all avaiable meal plans """
+    """ Returns a list of all available meal plans """
 
     return MealPlan.get_all()
 

--- a/mealie/services/backup_services.py
+++ b/mealie/services/backup_services.py
@@ -56,7 +56,7 @@ def import_from_archive(file_name: str) -> list:
     return successful_imports
 
 
-def export_db(tag=None, template=None):
+def export_db(tag=None, template=None) -> str:
     if tag:
         export_tag = tag + "_" + datetime.now().strftime("%Y-%b-%d")
     else:
@@ -79,6 +79,8 @@ def export_db(tag=None, template=None):
 
     shutil.rmtree(backup_folder)
     shutil.rmtree(TEMP_DIR)
+
+    return str(zip_path.absolute()) + ".zip"
 
 
 


### PR DESCRIPTION
This PR adds a small documentation note about variables availible for markdown export templates, fixes typos in function/api route names, and removes incorrect doctests. It also changes the success SnackReponse on the `export_database` route to display the absolute path of the backup file that was created.

Let me know if you'd like me to break this up into separate PRs instead!