### PR TITLE
Updated css % opacity values to fix 1% issue

### DIFF
--- a/frontend/src/components/Recipe.vue
+++ b/frontend/src/components/Recipe.vue
@@ -152,6 +152,6 @@ export default {
   margin-top: -10px;
 }
 .disabled-card {
-  opacity: 50%;
+  opacity: 0.5;
 }
 </style>

--- a/frontend/src/components/RecipeEditor/DetailsView.vue
+++ b/frontend/src/components/RecipeEditor/DetailsView.vue
@@ -123,6 +123,6 @@ export default {
 
 <style>
 .disabled-card {
-  opacity: 50%;
+  opacity: 0.5;
 }
 </style>

--- a/frontend/src/components/RecipeEditor/EditRecipe.vue
+++ b/frontend/src/components/RecipeEditor/EditRecipe.vue
@@ -276,7 +276,7 @@ export default {
 
 <style>
 .disabled-card {
-  opacity: 50%;
+  opacity: 0.5;
 }
 .my-divider {
   margin: 0 -1px;


### PR DESCRIPTION
The % opacity css values were all being changed to 1% in my builds, which I belive was due to this issue: https://github.com/cssnano/cssnano/issues/892 so I switched them to specify decimal opacity values instead.