### PR TITLE
Added Simple Field Validation to New Theme Modal

### DIFF
--- a/frontend/src/components/Admin/ThemeUI/NewTheme.vue
+++ b/frontend/src/components/Admin/ThemeUI/NewTheme.vue
@@ -5,10 +5,18 @@
       <v-card>
         <v-card-title> Add a New Theme </v-card-title>
         <v-card-text>
-          <v-text-field label="Theme Name" v-model="themeName"></v-text-field>
+          <v-text-field
+            label="Theme Name"
+            v-model="themeName"
+            :rules="[rules.required]"
+          ></v-text-field>
         </v-card-text>
         <v-card-actions>
-          <v-btn color="success" text @click="Select"> Create </v-btn>
+          <v-spacer></v-spacer>
+          <v-btn color="grey" text @click="dialog = false"> Cancel </v-btn>
+          <v-btn color="success" text @click="Select" :disabled="!themeName">
+            Create
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -19,19 +27,22 @@
 export default {
   props: {
     buttonText: String,
-    value: String,
+    value: String
   },
   data() {
     return {
       dialog: false,
       themeName: "",
+      rules: {
+        required: val => !!val || "Required."
+      }
     };
   },
 
   watch: {
     color() {
       this.updateColor();
-    },
+    }
   },
   methods: {
     randomColor() {
@@ -47,14 +58,14 @@ export default {
           success: this.randomColor(),
           info: this.randomColor(),
           warning: this.randomColor(),
-          error: this.randomColor(),
-        },
+          error: this.randomColor()
+        }
       };
 
       this.$emit("new-theme", newTheme);
       this.dialog = false;
-    },
-  },
+    }
+  }
 };
 </script>
 


### PR DESCRIPTION
With out the validation, a user can enter a blank theme name. When trying to delete the theme with no name, the call fails, leaving the blank theme there forever.

Blank Theme name: Unable to remove.
![image](https://user-images.githubusercontent.com/1888323/103689452-f28d6080-4f58-11eb-8377-6bbc0528c908.png)


First open: Disabled Create
![image](https://user-images.githubusercontent.com/1888323/103689098-75fa8200-4f58-11eb-84d1-621353b32f71.png)

Error state: Added field validation for required.
![image](https://user-images.githubusercontent.com/1888323/103689198-99bdc800-4f58-11eb-99b1-ae2afdcc7b26.png)

Successful validation:
![image](https://user-images.githubusercontent.com/1888323/103689049-654a0c00-4f58-11eb-9bc1-e851de933a8f.png)
