### PR TITLE
Normalize recipe instructions, yield, and image url

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,6 +10,7 @@ COPY ./requirements.txt /app/requirements.txt
 WORKDIR /app
 
 RUN pip install -r requirements.txt
+RUN pip install pytest
 
 COPY ./mealie /app
 
@@ -17,4 +18,4 @@ COPY ./mealie /app
 ENTRYPOINT [ "python" ]
 
 # TODO Reconfigure Command to start a Gunicorn Server that managed the Uvicorn Server. Also Learn how to do that :-/
-CMD [ "app.py" ] 
+CMD [ "app.py" ]

--- a/dev/scripts/scrape_recipe.py
+++ b/dev/scripts/scrape_recipe.py
@@ -1,0 +1,18 @@
+"""
+Helper script to download raw recipe data from a URL and dump it to disk.
+The resulting files can be used as test input data.
+"""
+
+import sys, json
+from scrape_schema_recipe import scrape_url
+
+for url in sys.argv[1:]:
+    try:
+        data = scrape_url(url)[0]
+        slug = list(filter(None, url.split("/")))[-1]
+        filename = f"{slug}.json"
+        with open(filename, "w") as f:
+            json.dump(data, f, indent=4, default=str)
+        print(f"Saved {filename}")
+    except Exception as e:
+        print(f"Error for {url}: {e}")

--- a/mealie/services/scrape_services.py
+++ b/mealie/services/scrape_services.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import json
 from pathlib import Path
 
@@ -12,10 +14,44 @@ CWD = Path(__file__).parent
 TEMP_FILE = CWD.parent.joinpath("data", "debug", "last_recipe.json")
 
 
-def normalize_data(recipe_data: dict) -> dict:
-    if type(recipe_data["recipeYield"]) == list:
-        recipe_data["recipeYield"] = recipe_data["recipeYield"][0]
+def normalize_image_url(image) -> str:
+    if type(image) == list:
+        return image[0]
+    elif type(image) == dict:
+        return image['url']
+    elif type(image) == str:
+        return image
+    else:
+        raise Exception(f"Unrecognised image URL format: {image}")
 
+
+def normalize_instructions(instructions) -> List[dict]:
+    # One long string split by (possibly multiple) new lines
+    if type(instructions) == str:
+        return [{"text": line.strip()} for line in filter(None, instructions.split("\n"))]
+
+    # Plain strings in a list
+    elif type(instructions) == list and type(instructions[0]) == str:
+        return [{"text": step.strip()} for step in instructions]
+
+    # Dictionaries (let's assume it's a HowToStep) in a list
+    elif type(instructions) == list and type(instructions[0]) == dict:
+        return [{"text": step['text'].strip()} for step in instructions if step['@type'] == 'HowToStep']
+
+    else:
+        raise Exception(f"Unrecognised instruction format: {instructions}")
+
+
+def normalize_yield(yld) -> str:
+    if type(yld) == list:
+        return yld[-1]
+    else:
+        return yld
+
+
+def normalize_data(recipe_data: dict) -> dict:
+    recipe_data["recipeYield"] = normalize_yield(recipe_data.get("recipeYield"))
+    recipe_data["recipeInstructions"] = normalize_instructions(recipe_data["recipeInstructions"])
     return recipe_data
 
 
@@ -52,7 +88,7 @@ def process_recipe_url(url: str) -> dict:
     new_recipe.update(mealie_tags)
 
     try:
-        img_path = scrape_image(new_recipe.get("image"), slug)
+        img_path = scrape_image(normalize_image_url(new_recipe.get("image")), slug)
         new_recipe["image"] = img_path.name
     except:
         new_recipe["image"] = None

--- a/mealie/test/data/Pizza-Knoblauch-Champignon-Paprika-vegan.html.json
+++ b/mealie/test/data/Pizza-Knoblauch-Champignon-Paprika-vegan.html.json
@@ -1,0 +1,103 @@
+{
+    "@context": "http://schema.org",
+    "@type": "Recipe",
+    "image": "https://img.chefkoch-cdn.de/rezepte/2235331358009600/bilder/864648/crop-960x540/pizza-knoblauch-champignon-paprika-vegan.jpg",
+    "recipeCategory": "Gem\u00fcse",
+    "recipeIngredient": [
+        "300 g Weizenmehl (Type 550)",
+        "1 Pck. Trockenhefe",
+        "1 TL Salz",
+        "170 ml Wasser",
+        "6 EL \u00d6l (Knoblauch\u00f6l oder Oliven\u00f6l)",
+        "1 EL Tomatenmark",
+        "n. B. Knoblauch , gew\u00fcrfelt",
+        "2  Spitzpaprika oder Gem\u00fcsepaprika, rot",
+        "250 g Champignons",
+        "1  Zwiebel(n)",
+        " Salz und Pfeffer",
+        " Kr\u00e4uter , italienische, frisch oder getrocknet",
+        " Harissa"
+    ],
+    "name": "Pizza Knoblauch Champignon Paprika - vegan",
+    "description": "Pizza Knoblauch Champignon Paprika - vegan - f\u00fcr Nicht-Veganer nat\u00fcrlich mit K\u00e4se zu belegen. \u00dcber 51 Bewertungen und f\u00fcr raffiniert befunden. Mit \u25ba Portionsrechner \u25ba Kochbuch \u25ba Video-Tipps!",
+    "recipeInstructions": "Die Zutaten f\u00fcr den Teig verkneten und ca. 40 Minuten an einem warmen Ort gehen lassen. In der Zwischenzeit eine beliebige Anzahl Knoblauchzehen fein w\u00fcrfeln (ich bedecke die Pizza nahezu fl\u00e4chendeckend), die Zwiebel ebenfalls w\u00fcrfeln, Paprika und Champignons klein schneiden. Das \u00d6l mit Tomatenmark, Salz und Pfeffer vermischen. \r\n\r\nDen fertigen Teig ausrollen und auf ein Blech legen (ich benutze eine Pflaumenkuchen-Backform). Die \u00d6lmischung mit einem Backpinsel gleichm\u00e4\u00dfig auf dem Teig verteilen, danach mit dem Knoblauch, den Champignons, der Paprika und den Zwiebeln belegen. \r\n\r\nNun die Pizza mit Salz, Pfeffer, Kr\u00e4utern und Harissa kr\u00e4ftig w\u00fcrzen und bei 250\u00b0C ca. 10 - 15 Minuten backen. Der Teig ist als Grundteig zu betrachten und l\u00e4sst sich nat\u00fcrlich mit allem M\u00f6glichen an Gem\u00fcse belegen.",
+    "author": {
+        "@type": "Person",
+        "name": "healing21"
+    },
+    "publisher": {
+        "@type": "Organization",
+        "name": "Chefkoch.de"
+    },
+    "datePublished": "2013-01-14",
+    "prepTime": "P0DT0H20M",
+    "cookTime": "P0DT0H15M",
+    "totalTime": "P0DT1H15M",
+    "recipeYield": "2 Portion(en)",
+    "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingCount": 51,
+        "ratingValue": 4.57,
+        "reviewCount": 34,
+        "worstRating": 0,
+        "bestRating": 5
+    },
+    "keywords": [
+        "Gem\u00fcse",
+        "Hauptspeise",
+        "Backen",
+        "Vegetarisch",
+        "einfach",
+        "Vegan",
+        "Pizza",
+        "Pilze"
+    ],
+    "reviews": [
+        {
+            "@type": "Review",
+            "reviewBody": " Sehr gutes Basis Rezept!\n\nHab noch Salami, Kochschinken und K\u00e4se dazu gemacht, sonst schmeckt es ja nach nichts. \n\nErgebnis: 1. Klasse! Sehr fein! ",
+            "datePublished": "2020-04-21",
+            "author": {
+                "@type": "Person",
+                "name": "eierkopp1824"
+            }
+        },
+        {
+            "@type": "Review",
+            "reviewBody": "Hallo,\r\nhabe den Teig gut zwei Stunden gehen lassen und dann wie im Rezept angegeben weiter verarbeitet. Da ich noch einige Schinkenw\u00fcrfel und etwas Fetak\u00e4se im K\u00fchlschrank hatte, wurden diese ebenfalls auf dem Belag verteilt.  Ich habe die Pizza auf der untersten Schiene im Backofen gebacken. Der Boden ist nach dem Backen sch\u00f6n knusprig. Es hat mir und meinem Mitesser sehr gut geschmeckt.\r\nLG von Sternek\u00f6chin2011",
+            "datePublished": "2020-03-10",
+            "author": {
+                "@type": "Person",
+                "name": "Sternek\u00f6chin2011"
+            }
+        },
+        {
+            "@type": "Review",
+            "reviewBody": "Echt f\u00fcr mich die leckerste Pizza auf der Welt! Auch bei meiner Familie kommt sie super an und \u00fcberlebt nicht lange. :)\nDen Belag kann man ja variieren wie man will. ",
+            "datePublished": "2020-02-20",
+            "author": {
+                "@type": "Person",
+                "name": "Leo090800"
+            }
+        },
+        {
+            "@type": "Review",
+            "reviewBody": "Beste Pizza, die ich je gegessen habe! Sooo lecker! Habe f\u00fcr den Teig Dinkelvollkornmehl genommen und den Belag noch mit ein paar Chiliflocken verfeinert. ",
+            "datePublished": "2018-04-15",
+            "author": {
+                "@type": "Person",
+                "name": "Sunny_Eyes"
+            }
+        },
+        {
+            "@type": "Review",
+            "reviewBody": "Der Teig ist super, ebenso wie die Sauce! Habe anstelle von normalem Salz Basilikumsalz in den Teig gegeben, das gibt dem ganzen einen besonderen Geschmack.Statt Paprika und Knobi habe ich K\u00e4se und Rucola hinzuef\u00fcgt, den Salat erst nach dem Backen. Die wird sicherlich nochmal gemacht! Da ich nur eine Pizza gemacht habe, habe ich den restlichen Teig eingefroren. Foto ist unterwegs!",
+            "datePublished": "2018-02-14",
+            "author": {
+                "@type": "Person",
+                "name": "Chiqryn"
+            }
+        }
+    ],
+    "url": "https://www.chefkoch.de/rezepte/2235331358009600/Pizza-Knoblauch-Champignon-Paprika-vegan.html"
+}

--- a/mealie/test/data/best-homemade-salsa-recipe.json
+++ b/mealie/test/data/best-homemade-salsa-recipe.json
@@ -1,0 +1,86 @@
+{
+    "@context": "http://schema.org/",
+    "@type": "Recipe",
+    "name": "The Best Homemade Salsa Recipe",
+    "author": {
+        "@type": "Person",
+        "name": "Sommer Collier"
+    },
+    "description": "How To Make Delicious Salsa: Secrets of making the Best Homemade Salsa Recipe! This restaurant style salsa recipe is loaded with flavor, has an amazing texture, and a secret ingredient.",
+    "datePublished": "2020-02-01T00:00:30+00:00",
+    "image": [
+        "https://www.aspicyperspective.com/wp-content/uploads/2019/02/the-best-homemade-salsa-recipe-100.jpg",
+        "https://www.aspicyperspective.com/wp-content/uploads/2019/02/the-best-homemade-salsa-recipe-100-500x500.jpg",
+        "https://www.aspicyperspective.com/wp-content/uploads/2019/02/the-best-homemade-salsa-recipe-100-500x375.jpg",
+        "https://www.aspicyperspective.com/wp-content/uploads/2019/02/the-best-homemade-salsa-recipe-100-480x270.jpg"
+    ],
+    "video": {
+        "name": "The Best Homemade Salsa Recipe",
+        "description": "We\u2019re sharing our secrets for making The Best Homemade Salsa Recipe we\u2019ve ever tried. Healthy, fresh, and easy to adjust!",
+        "thumbnailUrl": "https://content.jwplatform.com/thumbs/rPi8NdK6-720.jpg",
+        "contentUrl": "https://content.jwplatform.com/videos/rPi8NdK6.mp4",
+        "uploadDate": "2017-03-22T16:24:09.000Z",
+        "@type": "VideoObject"
+    },
+    "recipeYield": [
+        "20",
+        "20 (5 cups)"
+    ],
+    "prepTime": "PT5M",
+    "totalTime": "PT5M",
+    "recipeIngredient": [
+        "4  ripe tomatoes, (cored and quartered)",
+        "1  red onion, (peeled and quartered)",
+        "3  garlic cloves, (peeled)",
+        "3  jalapenos, (stemmed and seeded (you can\u00a0substitute 1-2 habanero or serrano peppers.))",
+        "1/3 cup fresh cilantro",
+        "3 tablespoons fresh lime juice",
+        "2-3 teaspoons ground cumin",
+        "2-3 teaspoons sugar ((optional))",
+        "1 1/2 teaspoons salt",
+        "15 ounces crushed San Marzano tomatoes ((1 can))",
+        "4.5 ounces diced green chiles, (mild, medium, or hot (1 can))"
+    ],
+    "recipeInstructions": [
+        {
+            "@type": "HowToStep",
+            "text": "Place the fresh tomatoes, onion, garlic, peppers, cilantro, lime juice, 2 teaspoons cumin, 2 teaspoons sugar (if using), and salt in a food processor. Pulse until the contents are fine and well blended.",
+            "name": "Place the fresh tomatoes, onion, garlic, peppers, cilantro, lime juice, 2 teaspoons cumin, 2 teaspoons sugar (if using), and salt in a food processor. Pulse until the contents are fine and well blended.",
+            "url": "https://www.aspicyperspective.com/best-homemade-salsa-recipe/#wprm-recipe-61842-step-0-0"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Pour in the crushed tomatoes and green chiles. Puree until mostly smooth. Taste, then add more cumin and sugar if desired. Refrigerate until ready to serve.",
+            "name": "Pour in the crushed tomatoes and green chiles. Puree until mostly smooth. Taste, then add more cumin and sugar if desired. Refrigerate until ready to serve.",
+            "url": "https://www.aspicyperspective.com/best-homemade-salsa-recipe/#wprm-recipe-61842-step-0-1"
+        }
+    ],
+    "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "4.98",
+        "ratingCount": "201"
+    },
+    "recipeCategory": [
+        "Appetizer",
+        "Snack"
+    ],
+    "recipeCuisine": [
+        "American",
+        "Mexican"
+    ],
+    "keywords": "Homemade Salsa, Salsa, The Best Salsa Recipe",
+    "nutrition": {
+        "@type": "NutritionInformation",
+        "servingSize": "0.25 cup",
+        "calories": "19 kcal",
+        "carbohydrateContent": "4 g",
+        "sodiumContent": "230 mg",
+        "sugarContent": "2 g"
+    },
+    "@id": "https://www.aspicyperspective.com/best-homemade-salsa-recipe/#recipe",
+    "isPartOf": {
+        "@id": "https://www.aspicyperspective.com/best-homemade-salsa-recipe/#article"
+    },
+    "mainEntityOfPage": "https://www.aspicyperspective.com/best-homemade-salsa-recipe/#webpage",
+    "url": "https://www.aspicyperspective.com/best-homemade-salsa-recipe/"
+}

--- a/mealie/test/data/blue-cheese-stuffed-turkey-meatballs-with-raspberry-balsamic-glaze-2.json
+++ b/mealie/test/data/blue-cheese-stuffed-turkey-meatballs-with-raspberry-balsamic-glaze-2.json
@@ -1,0 +1,36 @@
+{
+    "image": "https://www.cookingforkeeps.com/wp-content/uploads/2013/02/done-1.jpg",
+    "aggregateRating": {
+        "properties": {
+            "ratingValue": "4.0",
+            "ratingCount": "2"
+        },
+        "@type": "AggregateRating"
+    },
+    "name": "Blue Cheese Stuffed Turkey Meatballs with Raspberry Balsamic Glaze",
+    "author": "Nicole-Cooking for Keeps",
+    "recipeYield": "Makes 18-22 meatballs depending on size",
+    "recipeInstructions": [
+        "For the meatballs: Roll the blue cheese in small balls about the diameter of a dime. Freeze for 30 minutes. Preheat oven to 375 degrees. Mix the remaining ingredients together, until just combined. Roll sausage mixture into small balls. Place the blue cheese in the middle, enclosing with meat. Bake on a silt pad until golden brown and cooked through, about 25 min, turning halfway through to ensure even browning.",
+        "For the Dipping Sauce:",
+        "Combine all ingredients together in small sauce pan over medium high heat. Bring to a boil and then reduce heat and simmer about five minutes. Coat meatballs in sauce. Serve."
+    ],
+    "@context": "http://schema.org",
+    "@type": "Recipe",
+    "url": "https://www.cookingforkeeps.com/blue-cheese-stuffed-turkey-meatballs-with-raspberry-balsamic-glaze-2/",
+    "recipeIngredient": [
+        "Sausage Bites",
+        "3 oz creamy gorgonzola cheese",
+        "1 lb turkey Italian sausage (schmicas) with fennel seed",
+        "\u00bd cup Italian style bread crumbs",
+        "\u00bd onion grated",
+        "1 egg white",
+        "Salt to taste",
+        "Dipping Sauce:",
+        "\u00bd cup raspberry preserves",
+        "\u215b cup balsamic vinegar",
+        "3 teaspoons Dijon mustard",
+        "Pinch of red pepper",
+        "Pinch of Salt"
+    ]
+}

--- a/mealie/test/data/bon_appetit.json
+++ b/mealie/test/data/bon_appetit.json
@@ -1,0 +1,132 @@
+{
+    "@context": "http://schema.org",
+    "@type": "Recipe",
+    "articleBody": "Atlanta pastry chef Claudia Martinez\u2019s family has been making what Martinez describes as meaty Venezuelan tamales around the holidays for generations. In the Martinez household, every family member has a task: Claudia\u2019s dad or grandmother always prepares the guiso, the tender shredded chicken and beef stew that comprises the bulk of the filling. One person slicks scoops of vibrant orange achiote-stained masa dough onto banana leaves, then passes them around the table to get filled. Claudia\u2019s grandma adds a spoonful of guiso; Claudia adds olives and capers; her sister adds a few raisins. Finally, each hallaca gets wrapped up in the fragrant leaves and tied with twine like a tiny present, ready to boil for a late Christmas Eve dinner. The Martinez family usually makes 100 at a time; this scaled-down version of their recipe makes just under 20, enough for a big dinner plus leftovers you can freeze for another day. If you find yourself with leftover masa and stew, do as the Martinezes do: Make arepas with guiso and fried eggs for breakfast on Christmas Day. (If you\u2019re in Atlanta in the days leading up to Christmas Eve, pick up hallacas at Caf\u00e9 Claudia, the pop-up Martinez runs out of the Hotel Clermont.)\nBanana leaves give a floral and grassy flavor to the hallacas, you can buy them either fresh or frozen at Latin and Asian markets. You can use parchment paper instead, but the outcome won\u2019t be as complex.",
+    "alternativeHeadline": "The Venezuelan holiday dish that Atlanta pastry chef Claudia Martinez\u2019s family has been making for generations.",
+    "dateModified": "2021-01-02 12:09:30.443000",
+    "datePublished": "2020-12-01 07:00:00",
+    "keywords": [
+        "recipes",
+        "holiday 2020",
+        "new years eve",
+        "olive oil",
+        "beef",
+        "chicken recipes",
+        "kosher salt",
+        "tomato",
+        "garlic",
+        "tomato paste",
+        "onion",
+        "bell pepper",
+        "green onion scallion",
+        "cilantro",
+        "brown sugar",
+        "cornmeal",
+        "capers",
+        "olive",
+        "raisin",
+        "web"
+    ],
+    "thumbnailUrl": "https://assets.bonappetit.com/photos/5fb4407993a08c9bf97163f7/1:1/w_1125,h_1125,c_limit/1220-Hallacas.jpg",
+    "publisher": {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "Bon App\u00e9tit",
+        "logo": {
+            "@type": "ImageObject",
+            "url": "https://www.bonappetit.com/verso/static/bon-appetit/assets/logo-seo.328de564b950e3d5d1fbe3e42f065290ca1d3844.png",
+            "width": "479px",
+            "height": "100px"
+        },
+        "url": "https://www.bonappetit.com"
+    },
+    "isPartOf": {
+        "@type": [
+            "CreativeWork",
+            "Product"
+        ],
+        "name": "Bon App\u00e9tit"
+    },
+    "isAccessibleForFree": true,
+    "author": [
+        {
+            "@type": "Person",
+            "name": "Claudia Martinez",
+            "sameAs": "https://bon-appetit.com/contributor/claudia-martinez/"
+        }
+    ],
+    "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": 5,
+        "ratingCount": 22
+    },
+    "description": "The Venezuelan holiday dish that Atlanta pastry chef Claudia Martinez\u2019s family has been making for generations.",
+    "image": "hallacas.jpg",
+    "name": "Hallacas",
+    "recipeIngredient": [
+        "1\u00bd cups extra-virgin olive oil",
+        "3 Tbsp. plus 1\u00bd tsp. achiote (annatto) seeds",
+        "2\u00bd lb. boneless beef chuck roast",
+        "2\u00bd lb. skinless, boneless chicken breasts",
+        "1 Tbsp. Diamond Crystal or 1\u00be tsp. Morton kosher salt, plus more",
+        "3 medium tomatoes, coarsely chopped",
+        "3 garlic cloves",
+        "1 6-oz. can tomato paste",
+        "1 medium onion, chopped",
+        "1 large red bell pepper, seeds and ribs removed, coarsely chopped",
+        "1 large green bell pepper, seeds and ribs removed, coarsely chopped",
+        "1 bunch scallions, coarsely chopped",
+        "1 bunch cilantro, coarsely chopped",
+        "\u00bc cup (packed) light brown sugar",
+        "1 1-kg package P.A.N. precooked cornmeal",
+        "2 Tbsp. Diamond Crystal or 1 Tbsp. plus \u00bd tsp. kosher salt",
+        "3 1-lb. packages fresh or frozen, thawed banana or plantain leaves",
+        "\u00bc cup extra-virgin olive oil",
+        "\u00bd cup drained capers",
+        "\u00bd cup pitted green olives",
+        "\u00bd cup raisins"
+    ],
+    "recipeInstructions": [
+        {
+            "@type": "HowToStep",
+            "text": "Cook oil and achiote seeds in a small saucepan over medium-low heat until oil turns deep orange, about 10 minutes. Strain into a heatproof jar and let cool. Measure out \u00bd cup achiote oil for making filling; set remaining 1 cup oil aside for making dough."
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Bring beef, chicken, 1 Tbsp. Diamond Crystal or 1\u00be tsp. Morton kosher salt, and 12 cups water to a boil in a large pot over medium-high heat. Reduce heat to medium-low and let simmer until cooked through, about 30 minutes. Transfer beef and chicken to a cutting board and let sit until cool enough to handle. Pour 8 cups cooking liquid into a heatproof pitcher or large measuring glass; set aside. Discard any extra liquid."
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Cut beef and chicken into \u2153\" cubes; place back into pot (cooking the meat before you chop it means that you can cut the pieces finer and more evenly). Blend tomatoes, garlic, and tomato paste in a blender until smooth; scrape pur\u00e9e into pot with meat. Blend onion, red and green bell peppers, scallions, cilantro, and \u00bd cup reserved cooking liquid in blender until smooth and add to pot. Add brown sugar and \u00bd cup reserved achiote oil. Pour in remaining 7\u00bd cups reserved cooking liquid. Bring to a boil, then reduce heat to medium-low and simmer until meat is tender and liquid is slightly reduced, about 40 minutes. Drain meat in a colander, season lightly with salt, and let cool."
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Meanwhile, mix cornmeal, salt, reserved 1 cup achiote oil, and 8 cups water in a large bowl with your hands until dough is smooth, spreadable, and no large lumps remain, 5\u20137 minutes. Press a sheet of plastic wrap or parchment paper directly onto surface of dough; let rest at least 30 minutes or up to 1 hour."
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Wash and pat banana leaves dry. Carefully remove any center stems with kitchen shears, avoiding breaking through the leaf, then cut into 14x10\" rectangles. Mix oil and 1 cup water in a medium bowl (it needs to be big enough to dip your hands into). This will help to keep the dough from sticking to your hands. Working one at a time, place a banana leaf on a surface so the veins in the leaves run horizontally. Dipping your hands in oil mixture as you work, place \u00be cup dough in center of leaf and spread out with your fingers into a \u215b\"-thick rectangle, leaving a 1\" border near the vertical edges and a space on both horizontal edges. Place \u00be cup guiso into center of dough. Top with 5 capers, 2 olives, and 8 raisins."
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Take top and bottom edges of leaf and bring up toward each other so edges of dough meet and enclose filling. Pull both sides of banana leaf together snugly toward the upper edge of hallaca to seal and fold over toward you to make a tube. Fold remaining 2 side ends toward the center to make a small package."
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Place package, fold side down, on another banana leaf and wrap up again. Wrap once more in a third leaf to hold everything together, then tie closed with kitchen twine. (Make sure package is compact, the leaves are not ripped, and hallaca is not leaking.) Repeat with remaining dough, filling, and banana leaves."
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Place as many hallacas as will fit into a clean large pot, pour in water to cover, and bring to a boil. Reduce heat and simmer, turning hallacas halfway through, until plumped and firm, about 35 minutes. Repeat with remaining hallacas.\nDo ahead: Hallacas can be made 1 week ahead. Let cool, then cover and chill, or freeze up to 3 months. To reheat, cook in a pot of simmering water (make sure hallacas are submerged), partially covered, until warmed through, 10\u201315 minutes if chilled, 25\u201330 minutes if frozen."
+        }
+    ],
+    "recipeYield": "Makes about 18",
+    "url": "https://www.bonappetit.com/recipe/hallacas",
+    "slug": "hallacas",
+    "orgURL": "https://www.bonappetit.com/recipe/hallacas",
+    "categories": [],
+    "tags": [],
+    "dateAdded": null,
+    "notes": [],
+    "extras": []
+}

--- a/mealie/test/data/chunky-apple-cake.json
+++ b/mealie/test/data/chunky-apple-cake.json
@@ -1,0 +1,33 @@
+{
+    "url": "https://www.deliaonline.com/recipes/seasons/what-should-you-be-cooking-in-november/chunky-apple-cake",
+    "author": "Delia Smith",
+    "image": "https://www.deliaonline.com/sites/default/files/quick_media/cakes-chunky-apple-cake.jpg",
+    "name": "Chunky Apple Cake",
+    "description": "Apples are superb in cakes, so in the autumn when there are lots of windfalls around, why not make a few of these and freeze them.",
+    "recipeCuisine": "General",
+    "recipeCategory": [
+        "Apples",
+        "Afternoon Tea",
+        "Cake Recipes",
+        "Autumn",
+        "Life in the Freezer"
+    ],
+    "keywords": "Apples, Afternoon Tea, Cake Recipes, Autumn, Life in the Freezer, Delia, Delia Smith",
+    "recipeInstructions": "Begin by sifting the flour, baking powder and spices into a roomy mixing bowl, lifting the sieve quite high to give the flour a good airing as it goes down.\n\nNext chop the apples into small dice (with or without peel, just as you like). Then place them in a bowl and toss them with one tablespoon of the sieved flour mixture. Then add the eggs, butter and sugar to the rest of the flour, and using an electric hand whisk, combine them for about 1 minute until you have a smooth creamy consistency. After that fold in the grated orange zest, mixed peel and diced apple. If the mixture seems a little dry, add a tablespoon of milk. Now spoon the cake mix into the prepared tin and level it off with the back of a spoon.\n\nThen bake near the centre of the oven for about one hour or until the cake feels springy in the centre when lightly pressed with a fingertip and just shows signs of shrinking away from the edge of the tin. Cool in the tin for 10 minutes before turning out onto a wire rack. This looks nice dusted with sifted icing sugar just before serving. Store in an airtight tin.\n\nYou can watch more of Delia's cake recipes being made in our Cookery School Videos on the right.",
+    "recipeIngredient": [
+        "225g self-raising flour",
+        "1 rounded teaspoon baking powder",
+        "1 level teaspoon mixed spice",
+        "\u00bd level teaspoon ground cinnamon",
+        "3 Bramley apples (about 550g)",
+        "2 large eggs, beaten",
+        "75g spreadable butter",
+        "175g light brown soft sugar",
+        "grated zest of 1 large orange",
+        "1 tablespoon chopped mixed peel",
+        "1 tablespoon milk (if needed)",
+        "little icing sugar"
+    ],
+    "@context": "http://schema.org",
+    "@type": "Recipe"
+}

--- a/mealie/test/data/dairy-free-impossible-pumpkin-pie.json
+++ b/mealie/test/data/dairy-free-impossible-pumpkin-pie.json
@@ -1,0 +1,102 @@
+{
+    "@context": "http://schema.org/",
+    "@type": "Recipe",
+    "name": "Dairy-Free Impossible Pumpkin Pie",
+    "author": {
+        "@type": "Person",
+        "name": "Kare for Kitchen Treaty"
+    },
+    "description": "This crustless pumpkin pie might just be the\u00a0easiest\u00a0you'll ever make. Simply blend the ingredients together, pour into your pie pan, and bake!",
+    "datePublished": "2017-11-10T16:12:06+00:00",
+    "image": [
+        "https://www.kitchentreaty.com/wp-content/uploads/2017/11/dairy-free-impossible-pumpkin-pie-8.jpg"
+    ],
+    "recipeYield": [
+        "8"
+    ],
+    "prepTime": "PT10M",
+    "cookTime": "PT45M",
+    "totalTime": "PT55M",
+    "recipeIngredient": [
+        "1  (15-ounce) can coconut milk (I recommend full-fat for a richer pie, but lite also works)",
+        "1 cup pumpkin puree",
+        "4  large eggs",
+        "1/2 cup granulated sugar",
+        "1 tablespoon pure vanilla extract",
+        "1/2 cup all-purpose flour (or your favorite cup-for-cup gluten-free flour blend*)",
+        "1 teaspoon baking powder",
+        "1 tablespoon pumpkin pie spice",
+        "1/2 teaspoon fine-grain sea salt or table salt",
+        "Coconut whipped cream (for serving**)"
+    ],
+    "recipeInstructions": [
+        {
+            "@type": "HowToStep",
+            "text": "Preheat oven to 375 degrees Fahrenheit and position rack in the middle of the oven. Spray a 9- or 10-inch pie pan with baking spray or oil the pan with coconut oil or vegan butter.",
+            "name": "Preheat oven to 375 degrees Fahrenheit and position rack in the middle of the oven. Spray a 9- or 10-inch pie pan with baking spray or oil the pan with coconut oil or vegan butter.",
+            "url": "https://www.kitchentreaty.com/dairy-free-impossible-pumpkin-pie/#wprm-recipe-32856-step-0-0"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Add the coconut milk, pumpkin, eggs, sugar, and vanilla to the pitcher of a blender. Blend until combined, about 20 seconds. Add the flour, baking powder, pumpkin pie spice, and salt. Blend again until well-combined, another 20\u00a0seconds.",
+            "name": "Add the coconut milk, pumpkin, eggs, sugar, and vanilla to the pitcher of a blender. Blend until combined, about 20 seconds. Add the flour, baking powder, pumpkin pie spice, and salt. Blend again until well-combined, another 20\u00a0seconds.",
+            "url": "https://www.kitchentreaty.com/dairy-free-impossible-pumpkin-pie/#wprm-recipe-32856-step-0-1"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Pour filling into the pie plate. The mixture will be fairly runny. Carefully transfer to the preheated oven.",
+            "name": "Pour filling into the pie plate. The mixture will be fairly runny. Carefully transfer to the preheated oven.",
+            "url": "https://www.kitchentreaty.com/dairy-free-impossible-pumpkin-pie/#wprm-recipe-32856-step-0-2"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Bake\u00a0until the middle just barely jiggles, 40-50 minutes. I like to check the middle by giving the pie pan a little nudge, and if it seems like it's no longer liquid, I'll pull the pie out and insert a butter knife about halfway between the center and the edge. If the knife comes out relatively clean - no runny pie filling - it's\u00a0done!",
+            "name": "Bake\u00a0until the middle just barely jiggles, 40-50 minutes. I like to check the middle by giving the pie pan a little nudge, and if it seems like it's no longer liquid, I'll pull the pie out and insert a butter knife about halfway between the center and the edge. If the knife comes out relatively clean - no runny pie filling - it's\u00a0done!",
+            "url": "https://www.kitchentreaty.com/dairy-free-impossible-pumpkin-pie/#wprm-recipe-32856-step-0-3"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Place on a cooling rack and let cool, about 1 hour. Transfer to refrigerator to completely\u00a0cool, at least one more hour (or up to 3 days in advance).",
+            "name": "Place on a cooling rack and let cool, about 1 hour. Transfer to refrigerator to completely\u00a0cool, at least one more hour (or up to 3 days in advance).",
+            "url": "https://www.kitchentreaty.com/dairy-free-impossible-pumpkin-pie/#wprm-recipe-32856-step-0-4"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "If desired, top pie with dollops of coconut whipped cream. Or simply cut slices, transfer to a plate, and top\u00a0individual servings with the whipped cream.",
+            "name": "If desired, top pie with dollops of coconut whipped cream. Or simply cut slices, transfer to a plate, and top\u00a0individual servings with the whipped cream.",
+            "url": "https://www.kitchentreaty.com/dairy-free-impossible-pumpkin-pie/#wprm-recipe-32856-step-0-5"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Keeps in the refrigerator for 3-4 days. I suggest covering the completely cooled pie with plastic wrap if not serving right away.",
+            "name": "Keeps in the refrigerator for 3-4 days. I suggest covering the completely cooled pie with plastic wrap if not serving right away.",
+            "url": "https://www.kitchentreaty.com/dairy-free-impossible-pumpkin-pie/#wprm-recipe-32856-step-0-6"
+        }
+    ],
+    "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "5",
+        "ratingCount": "4"
+    },
+    "recipeCategory": [
+        "Dessert"
+    ],
+    "recipeCuisine": [
+        "American"
+    ],
+    "keywords": "pie",
+    "nutrition": {
+        "@type": "NutritionInformation",
+        "calories": "231 kcal",
+        "sugarContent": "14 g",
+        "sodiumContent": "239 mg",
+        "fatContent": "14 g",
+        "saturatedFatContent": "11 g",
+        "carbohydrateContent": "23 g",
+        "fiberContent": "1 g",
+        "proteinContent": "5 g",
+        "cholesterolContent": "82 mg",
+        "servingSize": "1 serving"
+    },
+    "url": "https://www.kitchentreaty.com/dairy-free-impossible-pumpkin-pie/"
+}

--- a/mealie/test/data/how-to-make-instant-pot-spaghetti.json
+++ b/mealie/test/data/how-to-make-instant-pot-spaghetti.json
@@ -1,0 +1,121 @@
+{
+    "@context": "http://schema.org/",
+    "@type": "Recipe",
+    "name": "How to Make Instant Pot Spaghetti",
+    "author": {
+        "@type": "Person",
+        "name": "Karlynn Johnston"
+    },
+    "description": "This Instant Pot Spaghetti recipe is literally the best one out there and it's thanks to one ( or two!) secret ingredients!",
+    "datePublished": "2020-09-15T13:00:52+00:00",
+    "image": [
+        "https://www.thekitchenmagpie.com/wp-content/uploads/images/2018/02/instantpotspaghetti.jpg",
+        "https://www.thekitchenmagpie.com/wp-content/uploads/images/2018/02/instantpotspaghetti-500x500.jpg",
+        "https://www.thekitchenmagpie.com/wp-content/uploads/images/2018/02/instantpotspaghetti-500x375.jpg",
+        "https://www.thekitchenmagpie.com/wp-content/uploads/images/2018/02/instantpotspaghetti-480x270.jpg"
+    ],
+    "recipeYield": [
+        "4"
+    ],
+    "prepTime": "PT15M",
+    "cookTime": "PT7M",
+    "totalTime": "PT22M",
+    "recipeIngredient": [
+        "1 tablespoon olive oil",
+        "1 cup white onion (diced)",
+        "1 tablespoon fresh minced garlic",
+        "1 pound lean ground beef",
+        "2 teaspoons Italian seasoning mix",
+        "one 16 ounce package uncooked white flour spaghetti noodles (cooking time for al dente needs to be 9-10 minutes! )",
+        "one 750 millilitre jar  of 4 cheese spaghetti sauce",
+        "one 15 ounce can diced tomatoes",
+        "3 cups weak beef broth (divided)",
+        "1/2 teaspoon salt (( to taste))",
+        "1/2 teaspoon black pepper",
+        "1/2  teaspoon white sugar (to cut the acidity of the tomatoes )"
+    ],
+    "recipeInstructions": [
+        {
+            "@type": "HowToStep",
+            "text": "Press the \"saute\" button on your Instant Pot. Add in the olive oil and heat. Once it's heated, add in the white onion. Saute until the onion is soft and translucent. Add in the garlic and fry for 2-3 minutes.",
+            "name": "Press the \"saute\" button on your Instant Pot. Add in the olive oil and heat. Once it's heated, add in the white onion. Saute until the onion is soft and translucent. Add in the garlic and fry for 2-3 minutes.",
+            "url": "https://www.thekitchenmagpie.com/how-to-make-instant-pot-spaghetti/#wprm-recipe-44488-step-0-0",
+            "image": "https://www.thekitchenmagpie.com/wp-content/uploads/images/2018/02/fryinggroundbeefandonionsinaninsantpot.jpg"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Add in the ground beef and fry , stirring constantly, until it's no longer pink. Press the Cancel button to turn off the Instant Pot heating element. Drain the fat (keeping some for flavour if wanted).",
+            "name": "Add in the ground beef and fry , stirring constantly, until it's no longer pink. Press the Cancel button to turn off the Instant Pot heating element. Drain the fat (keeping some for flavour if wanted).",
+            "url": "https://www.thekitchenmagpie.com/how-to-make-instant-pot-spaghetti/#wprm-recipe-44488-step-0-1"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Add in 1 cup of the beef broth, mixing it in with the ground beef on the bottom.",
+            "name": "Add in 1 cup of the beef broth, mixing it in with the ground beef on the bottom.",
+            "url": "https://www.thekitchenmagpie.com/how-to-make-instant-pot-spaghetti/#wprm-recipe-44488-step-0-2"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Break the spaghetti noodles in half. Place in random, different criss-cross patterns on top of the beef/ beef broth mixture. You are trying to created space between the noodles to try and prevent sticking.",
+            "name": "Break the spaghetti noodles in half. Place in random, different criss-cross patterns on top of the beef/ beef broth mixture. You are trying to created space between the noodles to try and prevent sticking.",
+            "url": "https://www.thekitchenmagpie.com/how-to-make-instant-pot-spaghetti/#wprm-recipe-44488-step-0-3",
+            "image": "https://www.thekitchenmagpie.com/wp-content/uploads/images/2018/02/howtobreakspaghettinoodlesfortheinstantpot.jpg"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "In a large bowl or large glass spouted measuring glass, combine the remaining beef broth, tomatoes, 4 cheese sauce, Italian seasoning, salt, pepper and dash of white sugar.&nbsp;",
+            "name": "In a large bowl or large glass spouted measuring glass, combine the remaining beef broth, tomatoes, 4 cheese sauce, Italian seasoning, salt, pepper and dash of white sugar.&nbsp;",
+            "url": "https://www.thekitchenmagpie.com/how-to-make-instant-pot-spaghetti/#wprm-recipe-44488-step-0-4"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Pout the liquid mixture on top of the pasta, around the sides, making sure you coat everything. Take a wooden spoon and gently push down on the spaghetti noodles, making sure that they are all underneath the liquid.",
+            "name": "Pout the liquid mixture on top of the pasta, around the sides, making sure you coat everything. Take a wooden spoon and gently push down on the spaghetti noodles, making sure that they are all underneath the liquid.",
+            "url": "https://www.thekitchenmagpie.com/how-to-make-instant-pot-spaghetti/#wprm-recipe-44488-step-0-5"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Press the Manual Button ( you are going to use high pressure) and set for 7 minutes. Listen to make sure that it seals.",
+            "name": "Press the Manual Button ( you are going to use high pressure) and set for 7 minutes. Listen to make sure that it seals.",
+            "url": "https://www.thekitchenmagpie.com/how-to-make-instant-pot-spaghetti/#wprm-recipe-44488-step-0-6"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "When it's done, release the valve manually ( see the link in my suggestions in the post above). Stir the spaghetti, breaking up any noodles that stuck together. Let it sit for a few minutes, soaking up the extra liquid.",
+            "name": "When it's done, release the valve manually ( see the link in my suggestions in the post above). Stir the spaghetti, breaking up any noodles that stuck together. Let it sit for a few minutes, soaking up the extra liquid.",
+            "url": "https://www.thekitchenmagpie.com/how-to-make-instant-pot-spaghetti/#wprm-recipe-44488-step-0-7",
+            "image": "https://www.thekitchenmagpie.com/wp-content/uploads/images/2018/02/instantpotspaghetti3.jpg"
+        }
+    ],
+    "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "5",
+        "ratingCount": "15"
+    },
+    "recipeCategory": [
+        "supper"
+    ],
+    "recipeCuisine": [
+        "American"
+    ],
+    "keywords": "Instant Pot Spaghetti",
+    "nutrition": {
+        "@type": "NutritionInformation",
+        "calories": "222 kcal",
+        "carbohydrateContent": "5 g",
+        "proteinContent": "27 g",
+        "fatContent": "9 g",
+        "saturatedFatContent": "3 g",
+        "cholesterolContent": "70 mg",
+        "sodiumContent": "699 mg",
+        "fiberContent": "1 g",
+        "sugarContent": "2 g",
+        "servingSize": "1 serving"
+    },
+    "@id": "https://www.thekitchenmagpie.com/how-to-make-instant-pot-spaghetti/#recipe",
+    "isPartOf": {
+        "@id": "https://www.thekitchenmagpie.com/how-to-make-instant-pot-spaghetti/#article"
+    },
+    "mainEntityOfPage": "https://www.thekitchenmagpie.com/how-to-make-instant-pot-spaghetti/#webpage",
+    "url": "https://www.thekitchenmagpie.com/how-to-make-instant-pot-spaghetti/"
+}

--- a/mealie/test/data/instant-pot-chicken-and-potatoes.json
+++ b/mealie/test/data/instant-pot-chicken-and-potatoes.json
@@ -1,0 +1,82 @@
+{
+    "@context": "http://schema.org/",
+    "@type": "Recipe",
+    "name": "Instant Pot Chicken and Potatoes",
+    "author": {
+        "@type": "Person",
+        "name": "Tiffany"
+    },
+    "description": "This is hands down the BEST Instant Pot Chicken and Potatoes recipe you'll ever try. Juicy ranch-seasoned chicken breast and parmesan potatoes cooked in 30 minutes in your pressure cooker - it doesn't get easier than this!&nbsp;",
+    "datePublished": "2018-10-26T07:00:51+00:00",
+    "image": [
+        "https://www.lecremedelacrumb.com/wp-content/uploads/2018/10/instant-pot-chicken-potatoes-2.jpg",
+        "https://www.lecremedelacrumb.com/wp-content/uploads/2018/10/instant-pot-chicken-potatoes-2-500x500.jpg",
+        "https://www.lecremedelacrumb.com/wp-content/uploads/2018/10/instant-pot-chicken-potatoes-2-500x375.jpg",
+        "https://www.lecremedelacrumb.com/wp-content/uploads/2018/10/instant-pot-chicken-potatoes-2-480x270.jpg"
+    ],
+    "recipeYield": [
+        "4",
+        "4 people"
+    ],
+    "prepTime": "PT10M",
+    "cookTime": "PT15M",
+    "totalTime": "PT40M",
+    "recipeIngredient": [
+        "4  boneless skinless chicken breasts",
+        "2 pounds baby red or gold potatoes",
+        "3 tablespoons olive oil",
+        "1 1/2 teaspoons salt (or to taste)",
+        "1/2 teaspoon pepper (or to taste)",
+        "1 teaspoon garlic powder",
+        "1 teaspoon dried thyme",
+        "1/2 teaspoon dried basil",
+        "1/2 teaspoon dried oregano",
+        "2 tablespoons + 2 teaspoons dry Ranch seasoning (divided)",
+        "1 cup  chicken broth",
+        "3 tablespoons grated parmesan cheese"
+    ],
+    "recipeInstructions": [
+        {
+            "@type": "HowToStep",
+            "text": "In a large bowl toss chicken and potatoes in the olive oil, then season with salt and pepper. Stir together garlic powder, thyme, basil, oregano, and 2 tablespoons of the Ranch seasoning. Sprinkle over the chicken and potatoes, tossing to distribute the ingredients as evenly as possible.&nbsp;",
+            "name": "In a large bowl toss chicken and potatoes in the olive oil, then season with salt and pepper. Stir together garlic powder, thyme, basil, oregano, and 2 tablespoons of the Ranch seasoning. Sprinkle over the chicken and potatoes, tossing to distribute the ingredients as evenly as possible.&nbsp;",
+            "url": "https://www.lecremedelacrumb.com/instant-pot-chicken-and-potatoes/#wprm-recipe-22284-step-0-0"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Add chicken broth to the instant pot/pressure cooker, then place chicken in the broth, and top with the potatoes. Place the lid on in the locked position and turn the vent to the sealed position.&nbsp;Set pressure cooker to \"pressure cook\" for 15 minutes.",
+            "name": "Add chicken broth to the instant pot/pressure cooker, then place chicken in the broth, and top with the potatoes. Place the lid on in the locked position and turn the vent to the sealed position.&nbsp;Set pressure cooker to \"pressure cook\" for 15 minutes.",
+            "url": "https://www.lecremedelacrumb.com/instant-pot-chicken-and-potatoes/#wprm-recipe-22284-step-0-1"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Once the cook time is finished, do a \"quick release\" by turning the vent to the venting position. Once float valve has dropped, remove the lid. Drain the pressure cooker or use a slotted spoon to transfer chicken and potatoes to a large platter.&nbsp;",
+            "name": "Once the cook time is finished, do a \"quick release\" by turning the vent to the venting position. Once float valve has dropped, remove the lid. Drain the pressure cooker or use a slotted spoon to transfer chicken and potatoes to a large platter.&nbsp;",
+            "url": "https://www.lecremedelacrumb.com/instant-pot-chicken-and-potatoes/#wprm-recipe-22284-step-0-2"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Sprinkle with Ranch seasoning and parmesan cheese and garnish with chopped thyme or parsley if desired before serving.&nbsp;",
+            "name": "Sprinkle with Ranch seasoning and parmesan cheese and garnish with chopped thyme or parsley if desired before serving.&nbsp;",
+            "url": "https://www.lecremedelacrumb.com/instant-pot-chicken-and-potatoes/#wprm-recipe-22284-step-0-3"
+        }
+    ],
+    "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "4.76",
+        "ratingCount": "225"
+    },
+    "recipeCategory": [
+        "Main Course"
+    ],
+    "recipeCuisine": [
+        "American"
+    ],
+    "keywords": "Chicken, healthy, instant pot, mashed potatoes, pressure cooker, ranch",
+    "@id": "https://www.lecremedelacrumb.com/instant-pot-chicken-and-potatoes/#recipe",
+    "isPartOf": {
+        "@id": "https://www.lecremedelacrumb.com/instant-pot-chicken-and-potatoes/#article"
+    },
+    "mainEntityOfPage": "https://www.lecremedelacrumb.com/instant-pot-chicken-and-potatoes/#webpage",
+    "url": "https://www.lecremedelacrumb.com/instant-pot-chicken-and-potatoes/"
+}

--- a/mealie/test/data/instant-pot-kerala-vegetable-stew.json
+++ b/mealie/test/data/instant-pot-kerala-vegetable-stew.json
@@ -1,0 +1,166 @@
+{
+    "@context": "http://schema.org/",
+    "@type": "Recipe",
+    "name": "How to make Instant Pot Kerala Vegetable Stew",
+    "author": {
+        "@type": "Person",
+        "name": "Dhwani"
+    },
+    "description": "Instant Pot Kerala Vegetable Stew - A complete Comfort and Satisfying food that can be made in a fraction of the time. Veg Stew is Vegetarian / Vegan Instant Pot Recipe with lots of vegetables in coconut milk based hearty sauce that will change your life.",
+    "datePublished": "2019-01-16T19:25:09+00:00",
+    "image": [
+        "https://cdn.cookingcarnival.com/wp-content/uploads/2019/01/Instant-Pot-Kerala-Vegetable-Stew-2.jpg",
+        "https://cdn.cookingcarnival.com/wp-content/uploads/2019/01/Instant-Pot-Kerala-Vegetable-Stew-2-500x500.jpg",
+        "https://cdn.cookingcarnival.com/wp-content/uploads/2019/01/Instant-Pot-Kerala-Vegetable-Stew-2-500x375.jpg",
+        "https://cdn.cookingcarnival.com/wp-content/uploads/2019/01/Instant-Pot-Kerala-Vegetable-Stew-2-480x270.jpg"
+    ],
+    "video": {
+        "name": "Instant Pot Kerala Vegetable Stew | Vegan stew recipe | vegetable Stew recipe in instant Pot",
+        "description": "Instant Pot Kerala Vegetable Stew - A complete Comfort and Satisfying food that can be made in a fraction of the time. Veg Stew is Vegetarian / Vegan Instant Pot Recipe with lots of vegetables in coconut milk based hearty sauce that will change your life.\n\nDetailed Recipe of Instant pot Kerela vegetable stew https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/\nOfficial Facebook Page: https://www.facebook.com/cookingcarnival\n\nPinterest: https://www.pinterest.com/cookingcarnival/\n\nTwitter: https://twitter.com/carnivalcooking\n\nGoogle Plus: https://plus.google.com/+Cookingcarnival\n\nInstagram: https://www.instagram.com/cookingcarnival",
+        "uploadDate": "2019-01-17T19:46:14+00:00",
+        "duration": "PT2M17S",
+        "thumbnailUrl": "https://i.ytimg.com/vi/pej98AtiBWE/hqdefault.jpg",
+        "contentUrl": "https://youtu.be/pej98AtiBWE",
+        "embedUrl": "https://www.youtube.com/embed/pej98AtiBWE?feature=oembed",
+        "@type": "VideoObject"
+    },
+    "recipeYield": [
+        "4",
+        "4 people"
+    ],
+    "prepTime": "PT10M",
+    "cookTime": "PT10M",
+    "totalTime": "PT20M",
+    "recipeIngredient": [
+        "2 cups - Cauliflower florets",
+        "1 cup - Chopped carrots",
+        "1 1/2 cup - Bell Peppers (chopped)",
+        "2 cups - Potatoes (Chopped)",
+        "3/4 cup - Chopped Onions",
+        "1 cup - Green beans (Chopped)",
+        "1 tsp - Ginger paste",
+        "1/2 tsp - Chili ((adust according to your liking) )",
+        "1 tsp - Garlic paste",
+        "2 -  Cardamom Pods (See Notes)",
+        "1 inch - Cinnamon stick",
+        "3 -  Cloves",
+        "20 Pieces - Whole Cashew Nuts",
+        "1 cup - Coconut milk (See Notes)",
+        "Salt to taste",
+        "1/2 tsp - White Pepper Powder (see notes)",
+        "2 tbsp - Oil (See Notes)",
+        "2 cups - Water"
+    ],
+    "recipeInstructions": [
+        {
+            "@type": "HowToStep",
+            "text": "Turn on saute button of your IP.",
+            "name": "Turn on saute button of your IP.",
+            "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#wprm-recipe-8126-step-0-0"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Heat oil in a pot, add cardamom pods, cinnamon stick, and cloves.",
+            "name": "Heat oil in a pot, add cardamom pods, cinnamon stick, and cloves.",
+            "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#wprm-recipe-8126-step-0-1"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Now add ginger, garlic, chili and onions. Saute for few seconds.",
+            "name": "Now add ginger, garlic, chili and onions. Saute for few seconds.",
+            "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#wprm-recipe-8126-step-0-2"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Add all the vegetables, salt, white pepper powder and water. Mix well.",
+            "name": "Add all the vegetables, salt, white pepper powder and water. Mix well.",
+            "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#wprm-recipe-8126-step-0-3"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Cover your Instant pot with locking lid.",
+            "name": "Cover your Instant pot with locking lid.",
+            "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#wprm-recipe-8126-step-0-4"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Turn off IP.",
+            "name": "Turn off IP.",
+            "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#wprm-recipe-8126-step-0-5"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Press the manual or pressure cook button. Cook on high pressure for 3 minutes with pressure valve in the sealing position.",
+            "name": "Press the manual or pressure cook button. Cook on high pressure for 3 minutes with pressure valve in the sealing position.",
+            "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#wprm-recipe-8126-step-0-6"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Meanwhile, take whole cashew and coconut milk in a blender jar and blend them well in to a smooth paste. Keep it aside.",
+            "name": "Meanwhile, take whole cashew and coconut milk in a blender jar and blend them well in to a smooth paste. Keep it aside.",
+            "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#wprm-recipe-8126-step-0-7"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Once IP beeps and when you see LO:00, turn off your IP and quick release the pressure.",
+            "name": "Once IP beeps and when you see LO:00, turn off your IP and quick release the pressure.",
+            "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#wprm-recipe-8126-step-0-8"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "10. Open the Instant Pot, add prepared cashew-coconut paste. Stir well.",
+            "name": "10. Open the Instant Pot, add prepared cashew-coconut paste. Stir well.",
+            "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#wprm-recipe-8126-step-0-9"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "11. Turn on saute button and cook it for 1 to 2 more minutes, until everything well combined.",
+            "name": "11. Turn on saute button and cook it for 1 to 2 more minutes, until everything well combined.",
+            "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#wprm-recipe-8126-step-0-10"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "12. Switch off the IP.",
+            "name": "12. Switch off the IP.",
+            "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#wprm-recipe-8126-step-0-11"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "13. Instant Pot Kerala Vegetable Stew is ready. Enjoy!!",
+            "name": "13. Instant Pot Kerala Vegetable Stew is ready. Enjoy!!",
+            "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#wprm-recipe-8126-step-0-12"
+        }
+    ],
+    "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "4.88",
+        "ratingCount": "8"
+    },
+    "recipeCategory": [
+        "Main Course",
+        "Soups and Stew"
+    ],
+    "recipeCuisine": [
+        "American",
+        "Indian"
+    ],
+    "keywords": "Easy vegan instant pot recipe, Instant pot, Vegetable Stew",
+    "nutrition": {
+        "@type": "NutritionInformation",
+        "servingSize": "1 person",
+        "calories": "201 kcal",
+        "carbohydrateContent": "24 g",
+        "proteinContent": "4 g",
+        "fatContent": "10 g",
+        "saturatedFatContent": "1 g",
+        "sodiumContent": "56 mg",
+        "fiberContent": "5 g",
+        "sugarContent": "9 g"
+    },
+    "@id": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#recipe",
+    "isPartOf": {
+        "@id": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#article"
+    },
+    "mainEntityOfPage": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/#webpage",
+    "url": "https://www.cookingcarnival.com/instant-pot-kerala-vegetable-stew/"
+}

--- a/mealie/test/data/jalapeno-popper-dip.json
+++ b/mealie/test/data/jalapeno-popper-dip.json
@@ -1,0 +1,89 @@
+{
+    "@context": "http://schema.org/",
+    "@type": "Recipe",
+    "name": "Jalape\u00f1o Popper Dip",
+    "author": {
+        "@type": "Person",
+        "name": "Michelle"
+    },
+    "description": "Jalapeno Popper Dip is creamy, cheesy and has just the perfect amount of kick. Great appetizer for your next party or watching the big game!",
+    "datePublished": "2016-02-22T00:01:37+00:00",
+    "image": [
+        "https://www.browneyedbaker.com/wp-content/uploads/2011/08/jalapeno-popper-dip-6-600.jpg"
+    ],
+    "recipeYield": [
+        "10",
+        "10 to 12 servings"
+    ],
+    "prepTime": "PT15M",
+    "cookTime": "PT30M",
+    "totalTime": "PT45M",
+    "recipeIngredient": [
+        "16 ounces cream cheese (at room temperature)",
+        "1 cup mayonnaise",
+        "8 pieces of bacon (cooked and chopped)",
+        "6  jalape\u00f1os (seeded and minced (if you can't get fresh, substitute a 4-ounce can diced jalape\u00f1o peppers, drained))",
+        "2 cloves garlic (minced)",
+        "\u00bd teaspoon cumin",
+        "6 ounces cheddar cheese (shredded (about 1\u00bd cups))",
+        "1 cup panko breadcrumbs",
+        "1 cup  grated Parmesan cheese",
+        "4 tablespoons  unsalted butter, melted"
+    ],
+    "recipeInstructions": [
+        {
+            "@type": "HowToStep",
+            "text": "Preheat oven to 375 degrees F.",
+            "name": "Preheat oven to 375 degrees F.",
+            "url": "https://www.browneyedbaker.com/jalapeno-popper-dip/#wprm-recipe-44993-step-0-0"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Combine the cream cheese, mayonnaise, bacon, jalapenos, garlic, cumin and cheddar cheese in a mixing bowl. Transfer the mixture into 2-quart baking dish.",
+            "name": "Combine the cream cheese, mayonnaise, bacon, jalapenos, garlic, cumin and cheddar cheese in a mixing bowl. Transfer the mixture into 2-quart baking dish.",
+            "url": "https://www.browneyedbaker.com/jalapeno-popper-dip/#wprm-recipe-44993-step-0-1"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Combine the panko breadcrumbs, Parmesan cheese and melted butter in a small bowl, tossing with a fork until the mixture is evenly moistened. Sprinkle evenly over the cream cheese mixture.",
+            "name": "Combine the panko breadcrumbs, Parmesan cheese and melted butter in a small bowl, tossing with a fork until the mixture is evenly moistened. Sprinkle evenly over the cream cheese mixture.",
+            "url": "https://www.browneyedbaker.com/jalapeno-popper-dip/#wprm-recipe-44993-step-0-2"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Bake in the preheated oven for 25 to 30 minutes, until the top is golden brown and the dip is bubbling. Let rest for 5 minutes before serving. Serve with your favorite tortilla chips, crackers, vegetables, etc.",
+            "name": "Bake in the preheated oven for 25 to 30 minutes, until the top is golden brown and the dip is bubbling. Let rest for 5 minutes before serving. Serve with your favorite tortilla chips, crackers, vegetables, etc.",
+            "url": "https://www.browneyedbaker.com/jalapeno-popper-dip/#wprm-recipe-44993-step-0-3"
+        }
+    ],
+    "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "4.34",
+        "ratingCount": "15"
+    },
+    "recipeCategory": [
+        "Appetizer"
+    ],
+    "recipeCuisine": [
+        "American"
+    ],
+    "keywords": "cheese dip, game day food, party food",
+    "nutrition": {
+        "@type": "NutritionInformation",
+        "calories": "560 kcal",
+        "carbohydrateContent": "7 g",
+        "proteinContent": "14 g",
+        "fatContent": "52 g",
+        "saturatedFatContent": "21 g",
+        "cholesterolContent": "109 mg",
+        "sodiumContent": "707 mg",
+        "sugarContent": "2 g",
+        "servingSize": "1 serving"
+    },
+    "@id": "https://www.browneyedbaker.com/jalapeno-popper-dip/#recipe",
+    "isPartOf": {
+        "@id": "https://www.browneyedbaker.com/jalapeno-popper-dip/#article"
+    },
+    "mainEntityOfPage": "https://www.browneyedbaker.com/jalapeno-popper-dip/#webpage",
+    "url": "https://www.browneyedbaker.com/jalapeno-popper-dip/"
+}

--- a/mealie/test/data/microwave_sweet_potatoes_04783.json
+++ b/mealie/test/data/microwave_sweet_potatoes_04783.json
@@ -1,0 +1,53 @@
+{
+    "@context": "https://schema.org",
+    "@type": "Recipe",
+    "aggregateRating": {
+        "ratingCount": 3,
+        "ratingValue": 4
+    },
+    "author": {
+        "@type": "Person",
+        "name": "Justine Pattison"
+    },
+    "cookTime": "PT10M",
+    "description": "Microwave jacket sweet potatoes make a wonderfully quick and easy meal. Take your pick of these three delicious fillings, or make all of them! The veggie chilli makes enough for four portions, great for lunch tomorrow. The smoked mackerel and pea fillings each make enough for two portions. \r\n\r\nThis recipe was tested using a 900W microwave oven. If your oven has more or fewer watts, you will need to adjust the cooking time.\r\n",
+    "image": [
+        "https://food-images.files.bbci.co.uk/food/recipes/microwave_sweet_potatoes_04783_16x9.jpg"
+    ],
+    "keywords": "quick, jacket potato dinners, microwave recipes , quick and cheap dinners, quick delicious lunches, easy family dinners, lunch, student food, Jacket potato, sweet potato, peas, egg free, gluten free, nut free, pregnancy friendly",
+    "name": "Microwave jacket sweet potato ",
+    "prepTime": "PT30M",
+    "recipeCategory": "Main course",
+    "recipeIngredient": [
+        "2 sweet potatoes, washed and dried",
+        "75g/2\u00bdoz smoked mackerel, skinned and roughly mashed with a fork",
+        "3 tbsp half-fat cr\u00e8me fra\u00eeche or soured cream",
+        "2 spring onions, trimmed and thinly sliced",
+        "\u00bd unwaxed lemon, finely grated zest only",
+        "freshly ground black pepper ",
+        "100g/3\u00bdoz frozen peas",
+        "100g/3\u00bdoz feta ",
+        "2 tbsp plain yoghurt",
+        "1 tbsp finely chopped fresh mint",
+        "freshly ground black pepper ",
+        "\u00bd red pepper, deseeded and diced",
+        "400g tin kidney beans in chilli sauce",
+        "198g tin sweetcorn in water",
+        "1 tbsp fresh lime juice",
+        "50g/1\u00beoz mature Cheddar, coarsely grated",
+        "4 tbsp soured cream",
+        "fresh coriander, to garnish",
+        "1 lime, cut into wedges, to serve"
+    ],
+    "recipeInstructions": [
+        "Prick the sweet potatoes two or three times with a fork and put on a microwaveable plate. Microwave on high for 5\u20136 minutes for one potato or 7\u20138 minutes for two. Test the potatoes are soft by inserting a skewer through the middle, it should slide in easily. If the potatoes remain a little hard, cook for longer, testing again every 30 seconds. Divide the potatoes between plates, make a cross in the centre and open to fill.",
+        "To make the smoked mackerel filling, mix all the ingredients together and season with lots of black pepper.",
+        "To make the pea and feta filling, microwave the peas on high for 2\u20133 minutes, until thawed and just warm. Mash them with a fork, until well broken up, then mix in the feta, yoghurt and mint. Season with lots of black pepper.",
+        "To make the veggie chilli filling, put the red pepper in a large microwavable bowl and cook on high for 1\u00bd\u20132 minutes, until soft. Add the beans and sweetcorn in its water, stir well and microwave on high for 4\u20135 minutes, until hot. Stir in the lime juice and mix well. Spoon into the cooked sweet potatoes and top with the cheese. Microwave for 1\u20132 minutes, until the cheese melts. Top with the soured cream, coriander and lime wedges. "
+    ],
+    "recipeYield": "Serves 2",
+    "suitableForDiet": [
+        "http://schema.org/GlutenFreeDiet"
+    ],
+    "url": "https://www.bbc.co.uk/food/recipes/microwave_sweet_potatoes_04783"
+}

--- a/mealie/test/data/moroccan-skirt-steak-with-roasted-pepper-couscous.json
+++ b/mealie/test/data/moroccan-skirt-steak-with-roasted-pepper-couscous.json
@@ -1,0 +1,243 @@
+{
+    "@context": "http://schema.org",
+    "@type": "Recipe",
+    "mainEntityOfPage": "http://www.eatingwell.com/recipe/249961/moroccan-skirt-steak-with-roasted-pepper-couscous/",
+    "name": "Moroccan Skirt Steak with Roasted Pepper Couscous",
+    "image": {
+        "@type": "ImageObject",
+        "url": "https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2019%2F08%2F26231251%2F3757257.jpg",
+        "width": 960,
+        "height": 960
+    },
+    "datePublished": "2016-06-03T04:27:31.000Z",
+    "description": "Thin cuts of beef, such as skirt steak or sirloin steak, cook very quickly when seared in a hot skillet--just right for a busy weeknight. We love how the spicy Moroccan flavors on the steak complement the sweet, roasted pepper-studded couscous. Serve with: Arugula salad and a glass of Pinot Noir.",
+    "prepTime": null,
+    "cookTime": null,
+    "totalTime": "P0DT0H35M",
+    "recipeIngredient": [
+        "2 medium bell peppers",
+        "1 teaspoon ground cumin",
+        "1 teaspoon ground coriander",
+        "\u00be teaspoon salt",
+        "\u00bd teaspoon ground turmeric",
+        "\u00bd teaspoon ground cinnamon",
+        "\u00bd teaspoon freshly ground pepper",
+        "1 whole lemon, plus more lemon wedges for garnish",
+        "1 tablespoon 1 teaspoon plus 1 tablespoon extra-virgin olive oil, divided",
+        "\u2154 cup whole-wheat couscous",
+        "1 pound 1 pound skirt steak (see Note) or sirloin steak, 3/4 to 1 inch thick, trimmed",
+        "2 tablespoons chopped green olives"
+    ],
+    "recipeInstructions": [
+        {
+            "@type": "HowToStep",
+            "text": "Position rack in upper third of oven; preheat broiler.\n"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Place bell peppers on a baking sheet and roast under the broiler, turning every 5 minutes, until charred and softened, 10 to 15 minutes. Transfer to a clean cutting board; when cool enough to handle, chop the peppers into bite-size pieces.\n"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Meanwhile, combine cumin, coriander, salt, turmeric, cinnamon and pepper in a small bowl. Grate 1/2 teaspoon zest from the lemon. Juice the lemon into a 1-cup measure and add enough water to make 1 cup. Pour into a small saucepan and add the lemon zest, 1 teaspoon of the spice mixture and 1 teaspoon olive oil. Bring to a boil. Stir in couscous, cover, remove from heat and let stand.\n"
+        },
+        {
+            "@type": "HowToStep",
+            "text": "Heat the remaining 1 tablespoon oil in a large skillet (preferably cast-iron) over medium heat until shimmering (but not smoking). Rub the remaining spice mixture on both sides of steak. Cook the steak 2 to 3 minutes per side for medium-rare. Let rest on the cutting board for 5 minutes. Stir olives and the peppers into the couscous. Thinly slice the steak and serve with the couscous and lemon wedges, if desired.\n"
+        }
+    ],
+    "recipeCategory": [
+        "Healthy Recipes",
+        "Healthy Ingredient Recipes",
+        "Healthy Meat & Poultry Recipes",
+        "Healthy Beef Recipes",
+        "Healthy Steak Recipes",
+        "Healthy New York Strip Steak Recipes"
+    ],
+    "recipeCuisine": [],
+    "author": [
+        {
+            "@type": "Person",
+            "name": "EatingWell Test Kitchen"
+        }
+    ],
+    "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": 4.538461538461538,
+        "ratingCount": 13,
+        "itemReviewed": "Moroccan Skirt Steak with Roasted Pepper Couscous",
+        "bestRating": "5",
+        "worstRating": "1"
+    },
+    "nutrition": {
+        "@type": "NutritionInformation",
+        "calories": "453.7 calories",
+        "carbohydrateContent": "36 g",
+        "cholesterolContent": "96.4 mg",
+        "fatContent": "18.4 g",
+        "fiberContent": "6.5 g",
+        "proteinContent": "36.4 g",
+        "saturatedFatContent": "5.1 g",
+        "servingSize": null,
+        "sodiumContent": "663.3 mg",
+        "sugarContent": null,
+        "transFatContent": null,
+        "unsaturatedFatContent": null
+    },
+    "review": [
+        {
+            "@type": "Review",
+            "datePublished": "2011-10-30T21:53:57Z",
+            "reviewBody": "Wow! This steak was fabulous. Full of flavor even my kids liked it. The spices for the steak rub get added to the cous cous. Along with the sweet roasted peppers it was so delicious.",
+            "reviewRating": {
+                "@type": "Rating",
+                "worstRating": "1",
+                "bestRating": "5",
+                "ratingValue": 5
+            },
+            "author": {
+                "@type": "Person",
+                "name": "shari_martinez@sbcglobal.net",
+                "image": null,
+                "sameAs": "https://www.allrecipes.com/cook/18308949/"
+            }
+        },
+        {
+            "@type": "Review",
+            "datePublished": "2011-10-30T02:40:11Z",
+            "reviewBody": "Not as well received as I had hoped The leftovers were good as a steak salad with honey-mustard seasoning although Kaja did not like the seasoned meat that way. I ate some couscous on my salad too. Leftover steak is unheard of at our house yet there it was. Offerred the kids a choice of unspiced steak (three takers) and Rice-a-Roni (four takers) Austin & I liked the steak Pros: Easy I liked it Cons: Nobody liked the couscous except me",
+            "reviewRating": {
+                "@type": "Rating",
+                "worstRating": "1",
+                "bestRating": "5",
+                "ratingValue": 3
+            },
+            "author": {
+                "@type": "Person",
+                "name": "Ellen",
+                "image": null,
+                "sameAs": "https://www.allrecipes.com/cook/19797391/"
+            }
+        },
+        {
+            "@type": "Review",
+            "datePublished": "2011-10-30T03:02:54Z",
+            "reviewBody": "tasty and easy weeknight meal Initially I was a little leery of using cinnamon to season the meat but it actually turned out very good. The seasoning had a tasty and light flavor. I used sirloin because the skirt steak at the store looked very fatty. The couscous (although I didn't add the olives because I'm not a huge fan) was also very good and I enjoyed the sweetness of the bell pepper. I used the lemon garnish to squeeze over the couscous and meat and think it made it. I would definitely make this again! Pros: Tasty and easy weeknight meal",
+            "reviewRating": {
+                "@type": "Rating",
+                "worstRating": "1",
+                "bestRating": "5",
+                "ratingValue": 4
+            },
+            "author": {
+                "@type": "Person",
+                "name": "Kat Y",
+                "image": null,
+                "sameAs": "https://www.allrecipes.com/cook/2343563/"
+            }
+        },
+        {
+            "@type": "Review",
+            "datePublished": "2011-10-30T17:25:23Z",
+            "reviewBody": "This was really good. It was definitely a change from what we're used to but in a good way. I had to use skillet steak because I couldn't find any skirt steak but it worked just fine. I also used the grill for the peppers and steak because my broiler is a bit questionable. Other than that I made it as stated and my husband and I really enjoyed it. A great out of the ordinary quick meal.",
+            "reviewRating": {
+                "@type": "Rating",
+                "worstRating": "1",
+                "bestRating": "5",
+                "ratingValue": 5
+            },
+            "author": {
+                "@type": "Person",
+                "name": "EatingWell User",
+                "image": null,
+                "sameAs": "https://www.allrecipes.com/cook/eatingwelluser/"
+            }
+        },
+        {
+            "@type": "Review",
+            "datePublished": "2011-10-30T03:41:53Z",
+            "reviewBody": "I love this recipe so much that I schedule it my meal planning as often as possible. The flavors with this cut of meat are just wonderful. I can't eat grains so I pair it with fennel. Perfect!",
+            "reviewRating": {
+                "@type": "Rating",
+                "worstRating": "1",
+                "bestRating": "5",
+                "ratingValue": 5
+            },
+            "author": {
+                "@type": "Person",
+                "name": "EatingWell User",
+                "image": null,
+                "sameAs": "https://www.allrecipes.com/cook/eatingwelluser/"
+            }
+        },
+        {
+            "@type": "Review",
+            "datePublished": "2013-02-20T17:33:48Z",
+            "reviewBody": "Great starting point! I like this one a lot but I would recommend the version of it on funnytummycafe.com. I've not been really adventurous with new flavors but this I will repeat! Pros: Wonderful flavors in the rub Cons: The couscous was TOO lemony",
+            "reviewRating": {
+                "@type": "Rating",
+                "worstRating": "1",
+                "bestRating": "5",
+                "ratingValue": 3
+            },
+            "author": {
+                "@type": "Person",
+                "name": "EatingWell User",
+                "image": null,
+                "sameAs": "https://www.allrecipes.com/cook/eatingwelluser/"
+            }
+        },
+        {
+            "@type": "Review",
+            "datePublished": "2011-10-30T15:06:11Z",
+            "reviewBody": "I made this with chicken instead of steak and it was great! My husband has not liked couscous in the past but he really liked this version. Will definitely make again!",
+            "reviewRating": {
+                "@type": "Rating",
+                "worstRating": "1",
+                "bestRating": "5",
+                "ratingValue": 5
+            },
+            "author": {
+                "@type": "Person",
+                "name": "EatingWell User",
+                "image": null,
+                "sameAs": "https://www.allrecipes.com/cook/eatingwelluser/"
+            }
+        },
+        {
+            "@type": "Review",
+            "datePublished": "2011-10-30T12:15:53Z",
+            "reviewBody": "WOW! Blew me away this was a great meal! Tons of flavor really quick and very filling! I served brown rice instead of couscous because that's what I had on hand. The husband never knew the difference! I can always tell when something is a real winner with him because he goes back for seconds (we're both on diets). I used one red and one green bell pepper and served a spring mix salad with tomato and feta on the side. Big bravo to the EatingWell kitchen! This will definitely be made again in my house!",
+            "reviewRating": {
+                "@type": "Rating",
+                "worstRating": "1",
+                "bestRating": "5",
+                "ratingValue": 5
+            },
+            "author": {
+                "@type": "Person",
+                "name": "EatingWell User",
+                "image": null,
+                "sameAs": "https://www.allrecipes.com/cook/eatingwelluser/"
+            }
+        },
+        {
+            "@type": "Review",
+            "datePublished": "2011-10-30T15:12:50Z",
+            "reviewBody": "Quick & easy to prepare with mild spiced flavor. The rub produces a great crust on the steak. I felt the lemon flavor dominated the cous cous though to be fair I did seem to have a particularly juicy lemon so that may be why. My husband and I both thought that the leftover steak would be superb sliced thinly in a sandwich with a mint/yogurt dressing.",
+            "reviewRating": {
+                "@type": "Rating",
+                "worstRating": "1",
+                "bestRating": "5",
+                "ratingValue": 5
+            },
+            "author": {
+                "@type": "Person",
+                "name": "EatingWell User",
+                "image": null,
+                "sameAs": "https://www.allrecipes.com/cook/eatingwelluser/"
+            }
+        }
+    ],
+    "url": "http://www.eatingwell.com/recipe/249961/moroccan-skirt-steak-with-roasted-pepper-couscous/"
+}

--- a/mealie/test/test_scraper.py
+++ b/mealie/test/test_scraper.py
@@ -1,0 +1,50 @@
+import pytest
+import json
+import os
+from pprint import pprint
+
+from services.scrape_services import normalize_data, normalize_instructions
+
+TEST_DATA_DIR = os.getenv("TEST_DATA_DIR")
+
+def pytest_generate_tests(metafunc):
+    # called once per each test function
+    funcarglist = metafunc.cls.params[metafunc.function.__name__]
+    argnames = sorted(funcarglist[0])
+    metafunc.parametrize(
+        argnames, [[funcargs[name] for name in argnames] for funcargs in funcarglist]
+    )
+
+
+class TestScraper:
+    # a map specifying multiple argument sets for a test method
+    params = {
+        "test_normalize_instructions": [
+            dict(instructions="A\n\nB\n\nC\n\n"),
+            dict(instructions=["A","B","C"]),
+            dict(instructions=[{"@type": "HowToStep", "text": "A"},
+                               {"@type": "HowToStep", "text": "B"},
+                               {"@type": "HowToStep", "text": "C"}]),
+        ],
+        "test_normalize_data": [
+            dict(json_file=f"{TEST_DATA_DIR}/best-homemade-salsa-recipe.json", num_steps=2),
+            dict(json_file=f"{TEST_DATA_DIR}/blue-cheese-stuffed-turkey-meatballs-with-raspberry-balsamic-glaze-2.json", num_steps=3),
+            dict(json_file=f"{TEST_DATA_DIR}/bon_appetit.json", num_steps=8),
+            dict(json_file=f"{TEST_DATA_DIR}/chunky-apple-cake.json", num_steps=4),
+            dict(json_file=f"{TEST_DATA_DIR}/dairy-free-impossible-pumpkin-pie.json", num_steps=7),
+            dict(json_file=f"{TEST_DATA_DIR}/how-to-make-instant-pot-spaghetti.json", num_steps=8),
+            dict(json_file=f"{TEST_DATA_DIR}/instant-pot-chicken-and-potatoes.json", num_steps=4),
+            dict(json_file=f"{TEST_DATA_DIR}/instant-pot-kerala-vegetable-stew.json", num_steps=13),
+            dict(json_file=f"{TEST_DATA_DIR}/jalapeno-popper-dip.json", num_steps=4),
+            dict(json_file=f"{TEST_DATA_DIR}/microwave_sweet_potatoes_04783.json", num_steps=4),
+            dict(json_file=f"{TEST_DATA_DIR}/moroccan-skirt-steak-with-roasted-pepper-couscous.json", num_steps=4),
+            dict(json_file=f"{TEST_DATA_DIR}/Pizza-Knoblauch-Champignon-Paprika-vegan.html.json", num_steps=5),
+        ]
+    }
+
+    def test_normalize_data(self, json_file, num_steps):
+        recipe_data = normalize_data(json.load(open(json_file)))
+        assert len(recipe_data["recipeInstructions"]) == num_steps
+
+    def test_normalize_instructions(self, instructions):
+        assert normalize_instructions(instructions) == [{"text": "A"}, {"text": "B"}, {"text": "C"}]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,6 +5,7 @@ APScheduler==3.6.3
 astroid==2.4.2
 async-exit-stack==1.0.1
 async-generator==1.10
+attrs==20.3.0
 beautifulsoup4==4.9.1
 black==20.8b1
 certifi==2020.6.20
@@ -24,6 +25,7 @@ html-text==0.5.2
 html5lib==1.1
 httptools==0.1.1
 idna==2.10
+iniconfig==1.1.1
 isodate==0.6.0
 isort==5.4.2
 itsdangerous==1.1.0
@@ -36,12 +38,16 @@ mccabe==0.6.1
 mf2py==1.1.2
 mongoengine==0.21.0
 mypy-extensions==0.4.3
+packaging==20.8
 pathspec==0.8.0
+pluggy==0.13.1
 promise==2.3
+py==1.10.0
 pydantic==1.6.1
 pylint==2.6.0
 pymongo==3.11.1
 pyparsing==2.4.7
+pytest==6.2.1
 python-dateutil==2.8.1
 python-dotenv==0.15.0
 python-multipart==0.0.5
@@ -50,7 +56,7 @@ pytz==2020.4
 PyYAML==5.3.1
 rdflib==4.2.2
 rdflib-jsonld==0.5.0
-regex==2020.7.14
+regex==2020.11.13
 requests==2.24.0
 Rx==1.6.1
 scrape-schema-recipe==0.1.1


### PR DESCRIPTION
Including tests and example recipe data. 

pytest is used as the test framework, hence the new dev dependencies 
The tests can either be run in a local virtualenv
```
TEST_DATA_DIR=mealie/test/data pytest
```
or in the `mealie-api` docker container
```
docker run --rm -it --entrypoint pytest -e "TEST_DATA_DIR=/app/test/data" mealie-api:dev
```

This fixes some, but not all URLs reported in #7. The remaining ones do not contain any `json-ld` metadata or markup and hence cannot be scraped by `scrape_schema_recipe.scrape_url`.