### PR TITLE
Fix link to Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
     Request Feature
     </a>    
     ·
-    <a href="https://hub.docker.com/repository/docker/hkotel/mealies"> Docker Hub
+    <a href="https://hub.docker.com/repository/docker/hkotel/mealie"> Docker Hub
     </a>
 </p>
 


### PR DESCRIPTION
Found an extra s. DESTROYED it.