### PR TITLE
Consider any .json file from Nextcloud

### DIFF
--- a/mealie/services/migrations/nextcloud.py
+++ b/mealie/services/migrations/nextcloud.py
@@ -28,7 +28,8 @@ def import_recipes(recipe_dir: Path) -> Recipe:
     for file in recipe_dir.glob("full.*"):
         image = file
 
-    recipe_file = recipe_dir.joinpath("recipe.json")
+    for file in recipe_dir.glob("*.json"):
+        recipe_file = file
 
     with open(recipe_file, "r") as f:
         recipe_dict = json.loads(f.read())
@@ -81,6 +82,7 @@ def migrate(session, selection: str):
                 successful_imports.append(recipe.name)
             except:
                 logging.error(f"Failed Nextcloud Import: {dir.name}")
+                logging.exception('')
                 failed_imports.append(dir.name)
 
     cleanup()


### PR DESCRIPTION
In some cases, Nextcloud names the ,json file with the recipe name (example: Guacamole.json) instead of the default recipe,json.

I also took the liberty to add the stacktrace to the log in case of error. 