### PR TITLE
Allow empty instructions

### DIFF
--- a/mealie/services/scrape_services.py
+++ b/mealie/services/scrape_services.py
@@ -35,6 +35,9 @@ def normalize_image_url(image) -> str:
 
 
 def normalize_instructions(instructions) -> List[dict]:
+    if not instructions:
+        return []
+
     # One long string split by (possibly multiple) new lines
     if type(instructions) == str:
         return [


### PR DESCRIPTION
Some recipes may not have any instructions, for example cocktails or sauces. They only list ingredients.
This change allows importing recipes without instructions.