### PR TITLE
Initialize language settings earlier

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -71,13 +71,13 @@ export default {
         this.search = !this.search;
       }
     });
+    this.$store.dispatch("initLang");
   },
 
   mounted() {
     this.$store.dispatch("initTheme");
     this.$store.dispatch("requestRecentRecipes");
     this.$store.dispatch("requestHomePageSettings");
-    this.$store.dispatch("initLang");
     this.darkModeSystemCheck();
     this.darkModeAddEventListener();
   },


### PR DESCRIPTION
Some components were already loaded before "mounted" is triggered, such as the category sidebar or the top-right menu, leading to strings being displayed in the default English language. 
![image](https://user-images.githubusercontent.com/34862846/110202058-af6f4100-7e66-11eb-8d68-4ead586192cb.png)
![image](https://user-images.githubusercontent.com/34862846/110202060-b39b5e80-7e66-11eb-8796-a4d316219347.png)
