### PR TITLE
Do not force theme settings on login form

### DIFF
--- a/frontend/src/components/Login/LoginForm.vue
+++ b/frontend/src/components/Login/LoginForm.vue
@@ -22,13 +22,11 @@
         <v-text-field
           v-if="!options.isLoggingIn"
           v-model="user.name"
-          light="light"
           prepend-icon="person"
           :label="$t('general.name')"
         ></v-text-field>
         <v-text-field
           v-model="user.email"
-          light="light"
           prepend-icon="mdi-email"
           validate-on-blur
           :label="$t('user.email')"
@@ -36,7 +34,6 @@
         ></v-text-field>
         <v-text-field
           v-model="user.password"
-          light="light"
           class="mb-2s"
           prepend-icon="mdi-lock"
           :label="$t('user.password')"
@@ -47,7 +44,6 @@
         <v-card-actions>
           <v-btn
             v-if="options.isLoggingIn"
-            dark
             color="primary"
             block="block"
             type="submit"


### PR DESCRIPTION
If the site was in dark mode, fields were black on dark grey.
![image](https://user-images.githubusercontent.com/34862846/113502190-f8301d80-952a-11eb-9bfd-c06d1de4576c.png)
