### PR TITLE
Fix docker dev db persistence

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,4 +19,4 @@ COPY ./mealie /app/mealie
 RUN poetry install 
 
 RUN chmod +x /app/mealie/run.sh
-CMD /app/mealie/run.sh
+CMD /app/mealie/run.sh reload

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -18,4 +18,5 @@ COPY ./mealie /app/mealie
 
 RUN poetry install 
 
-CMD ["poetry", "run", "python", "mealie/app.py"]
+RUN chmod +x /app/mealie/run.sh
+CMD /app/mealie/run.sh

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,12 +14,8 @@ RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-
 # Copy poetry.lock* in case it doesn't exist in the repo
 COPY ./pyproject.toml /app/
 
-# RUN poetry install 
-
 COPY ./mealie /app/mealie
 
 RUN poetry install 
 
-RUN ["poetry", "run", "python", "mealie/db/init_db.py"]
-RUN ["poetry", "run", "python", "mealie/services/image/minify.py"]
 CMD ["poetry", "run", "python", "mealie/app.py"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,7 @@ services:
       db_type: sqlite
       TZ: America/Anchorage # Specify Correct Timezone for Date/Time to line up correctly.
     volumes:
-      - ./app_data:/app_data
+      - ./dev/data:/app/dev/data
       - ./mealie:/app/mealie
 
   # Mkdocs

--- a/makefile
+++ b/makefile
@@ -53,6 +53,8 @@ setup: ## Setup Development Instance
 	cd ..
 
 backend: ## Start Mealie Backend Development Server
+	poetry run python mealie/db/init_db.py && \
+	poetry run python mealie/services/image/minify.py && \
 	poetry run python mealie/app.py
 
 

--- a/makefile
+++ b/makefile
@@ -53,8 +53,6 @@ setup: ## Setup Development Instance
 	cd ..
 
 backend: ## Start Mealie Backend Development Server
-	poetry run python mealie/db/init_db.py && \
-	poetry run python mealie/services/image/minify.py && \
 	poetry run python mealie/app.py
 
 

--- a/mealie/app.py
+++ b/mealie/app.py
@@ -10,6 +10,8 @@ from mealie.routes.mealplans import mealplans
 from mealie.routes.recipe import all_recipe_routes, category_routes, recipe_crud_routes, tag_routes
 from mealie.routes.site_settings import all_settings
 from mealie.routes.users import users
+from mealie.db import init_db
+from mealie.services.image import minify
 
 app = FastAPI(
     title="Mealie",
@@ -51,6 +53,8 @@ start_scheduler()
 
 
 def main():
+    init_db.main()
+    minify.migrate_images()
 
     uvicorn.run(
         "app:app",

--- a/mealie/app.py
+++ b/mealie/app.py
@@ -10,8 +10,6 @@ from mealie.routes.mealplans import mealplans
 from mealie.routes.recipe import all_recipe_routes, category_routes, recipe_crud_routes, tag_routes
 from mealie.routes.site_settings import all_settings
 from mealie.routes.users import users
-from mealie.db import init_db
-from mealie.services.image import minify
 
 app = FastAPI(
     title="Mealie",
@@ -53,9 +51,7 @@ start_scheduler()
 
 
 def main():
-    init_db.main()
-    minify.migrate_images()
-
+    
     uvicorn.run(
         "app:app",
         host="0.0.0.0",

--- a/mealie/db/init_db.py
+++ b/mealie/db/init_db.py
@@ -47,11 +47,12 @@ def default_user_init(session: Session):
     logger.info("Generating Default User")
     db.users.create(session, default_user)
 
-
-if __name__ == "__main__":
+def main():
     if sql_exists:
         print("Database Exists")
-        exit()
     else:
         print("Database Doesn't Exists, Initializing...")
         init_db()
+
+if __name__ == "__main__":
+    main()

--- a/mealie/run.sh
+++ b/mealie/run.sh
@@ -10,7 +10,7 @@ python mealie/services/image/minify.py
 ## Migrations
 # TODO
 
-if [[ "$ARG1" = "reload" ]]
+if [ "$ARG1" = "reload" ] 
 then
     echo "Hot reload"
 

--- a/mealie/run.sh
+++ b/mealie/run.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Get Reload Arg `run.sh reload` for dev server
+ARG1=${1:-production}
+
 # Initialize Database Prerun
 python mealie/db/init_db.py
 python mealie/services/image/minify.py
@@ -7,8 +10,17 @@ python mealie/services/image/minify.py
 ## Migrations
 # TODO
 
-## Web Server
-caddy start --config ./Caddyfile
+if [[ "$ARG1" = "reload" ]]
+then
+    echo "Hot reload"
 
-# Start API
-uvicorn mealie.app:app --host 0.0.0.0 --port 9000
+    # Start API
+    uvicorn mealie.app:app --host 0.0.0.0 --port 9000 --reload
+else
+    echo "Production config"
+    # Web Server
+    caddy start --config ./Caddyfile
+
+    # Start API
+    uvicorn mealie.app:app --host 0.0.0.0 --port 9000
+fi


### PR DESCRIPTION
- Changed app_data to /app/dev/data
- app.py is now the single entrypoint: initialization is done there. This was needed because the RUN commands in Dockerfile were broken (initialization was done prior to volume mounts).

I still need to test the docker production build, not sure yet if the initialization in run.sh is still needed. 