### PR TITLE
Fix ingredients list not being refreshed upon recipe change

### DIFF
--- a/frontend/src/components/Recipe/RecipeViewer/Ingredients.vue
+++ b/frontend/src/components/Recipe/RecipeViewer/Ingredients.vue
@@ -37,16 +37,13 @@ export default {
   props: {
     ingredients: Array,
   },
-  data() {
-    return {
-      displayIngredients: [],
-    };
-  },
-  mounted() {
-    this.displayIngredients = this.ingredients.map(x => ({
-      text: x,
-      checked: false,
-    }));
+  computed: {
+    displayIngredients() {
+      return this.ingredients.map(x => ({
+        text: x,
+        checked: false,
+      }));
+    },
   },
   methods: {
     generateKey(item, index) {


### PR DESCRIPTION
When you search for a new recipe while already viewing one, everything is correctly displayed except for the ingredients list.