### PR TITLE
Fix infinite loop in meal planner randomizer

### DIFF
--- a/frontend/src/components/MealPlan/MealPlanNew.vue
+++ b/frontend/src/components/MealPlan/MealPlanNew.vue
@@ -167,11 +167,7 @@ export default {
       }
     },
     getRandom(list) {
-      let recipe = 1;
-      while (this.usedRecipes.includes(recipe)) {
-        recipe = list[Math.floor(Math.random() * list.length)];
-      }
-      return recipe;
+      return list[Math.floor(Math.random() * list.length)];
     },
     random() {
       this.usedRecipes = [1];


### PR DESCRIPTION
Infinite loop would happen if there were more days than recipes.

It would probably be better to enhance the algorithm or at least warn the user, but since it's an edge case it's low prio.