### PR TITLE
Fixed backup, updated backup docu

### DIFF
--- a/docs/docs/site-administration/backups-and-exports.md
+++ b/docs/docs/site-administration/backups-and-exports.md
@@ -38,16 +38,24 @@ curl -X 'POST' \
     "settings": true,
     "themes": true
   },
-  "template": [
+  "templates": [
     "recipes.md"
   ]
 }'
 ```
 
 ### wget Example
-Download a backup with `wget`
+First request a file token with curl:
 ```bash
-wget http://localhost:9000/api/backups/{file_name}/download
+curl -X 'GET' \
+  'http://localhost:9000/api/backups/{file_name}/download' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json'
+```
+
+Then download the file with wget:
+```bash
+wget http://localhost:9000/api/utils/download?token={fileToken}
 ```
 
 

--- a/mealie/routes/utility_routes.py
+++ b/mealie/routes/utility_routes.py
@@ -9,7 +9,7 @@ from fastapi import HTTPException, status
 router = APIRouter(prefix="/api/utils", tags=["Utils"], include_in_schema=True)
 
 
-@router.get("/download")
+@router.get("/download/{token}")
 async def download_file(file_path: Optional[Path] = Depends(validate_file_token)):
     """Uses a file token obtained by an active user to retrieve a file from the operating
     system."""

--- a/mealie/services/backups/exports.py
+++ b/mealie/services/backups/exports.py
@@ -36,12 +36,12 @@ class ExportDatabase:
         self.recipes = self.main_dir.joinpath("recipes")
         self.templates_dir = self.main_dir.joinpath("templates")
 
-        try:
+        try:    
             self.templates = [app_dirs.TEMPLATE_DIR.joinpath(x) for x in templates]
         except Exception:
             self.templates = False
             logger.info("No Jinja2 Templates Registered for Export")
-
+        
         required_dirs = [
             self.main_dir,
             self.recipes,
@@ -52,21 +52,22 @@ class ExportDatabase:
             dir.mkdir(parents=True, exist_ok=True)
 
     def export_templates(self, recipe_list: list[BaseModel]):
-        for template_path in self.templates:
-            out_dir = self.templates_dir.joinpath(template_path.name)
-            out_dir.mkdir(parents=True, exist_ok=True)
+        if self.templates:
+            for template_path in self.templates:
+                out_dir = self.templates_dir.joinpath(template_path.name)
+                out_dir.mkdir(parents=True, exist_ok=True)
 
-            with open(template_path, "r") as f:
-                template = Template(f.read())
+                with open(template_path, "r") as f:
+                    template = Template(f.read())
 
-            for recipe in recipe_list:
-                filename = recipe.slug + template_path.suffix
-                out_file = out_dir.joinpath(filename)
+                for recipe in recipe_list:
+                    filename = recipe.slug + template_path.suffix
+                    out_file = out_dir.joinpath(filename)
 
-                content = template.render(recipe=recipe)
+                    content = template.render(recipe=recipe)
 
-                with open(out_file, "w") as f:
-                    f.write(content)
+                    with open(out_file, "w") as f:
+                        f.write(content)
 
     def export_recipe_dirs(self):
         shutil.copytree(app_dirs.RECIPE_DATA_DIR, self.recipes, dirs_exist_ok=True)

--- a/mealie/services/backups/exports.py
+++ b/mealie/services/backups/exports.py
@@ -36,12 +36,12 @@ class ExportDatabase:
         self.recipes = self.main_dir.joinpath("recipes")
         self.templates_dir = self.main_dir.joinpath("templates")
 
-        try:    
+        try:
             self.templates = [app_dirs.TEMPLATE_DIR.joinpath(x) for x in templates]
         except Exception:
             self.templates = False
             logger.info("No Jinja2 Templates Registered for Export")
-        
+
         required_dirs = [
             self.main_dir,
             self.recipes,


### PR DESCRIPTION
Hi,
I wanted to setup an automatic backup via cronjob but noticed that the docu is not up to date. There's also a small error if the `templates` attribute in `/api/backups/export/database` is not set even though it's marked as optional.

I've also tried to regenerate the swagger json but there's a still an error with the example value in the `template` attribute and I don't know how to fix it:
```json
{
  "tag": "July 23rd 2021",
  "options": {
    "recipes": true,
    "settings": true,
    "pages": true,
    "themes": true,
    "groups": true,
    "users": true,
    "notifications": true
  },
  "template": [
    "recipes.md"
  ]
}
```
Accordingly to the `BackupJob` model it must be in plural `templates`. The schema in swagger is btw correct, it's just about the example.