### PR TITLE
handle recipeInstructions that are given as json objects / name-value…

### DIFF
--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -70,6 +70,10 @@ class Cleaner:
         if not instructions:
             return []
 
+        # Dictionary (Keys: step number strings, Values: the instructions)
+        if isinstance(instructions, dict):                            
+           instructions = list(instructions.values())    
+
         if isinstance(instructions[0], list):
             instructions = instructions[0]
 


### PR DESCRIPTION
I had trouble migrating recipes from nextcloud cookbook. I split down the zip that I tried to import so that each zip file contains a single recipe. I found that some recipes could be migrated like that and some could not. Those that could not be migrated use a different format for the recipe instructions like so:
`"recipeInstructions":{"0":"Einen Topf ...","2":"In der Zwischenzeit ...", "6":"Auf dem Grill ..."}`

I made this change directly on my docker container. It works for me. I hope it breaks no other migrations. 
 