### PR TITLE
Reset disabled steps when switching recipe

### DIFF
--- a/frontend/src/components/Recipe/Parts/Instructions.vue
+++ b/frontend/src/components/Recipe/Parts/Instructions.vue
@@ -91,6 +91,15 @@ export default {
   mounted() {
     this.showTitleEditor = this.value.map(x => this.validateTitle(x.title));
   },
+
+  watch: {
+    value: {
+      handler() { 
+        this.disabledSteps = [];  
+      }
+    }
+  },
+  
   methods: {
     generateKey(item, index) {
       return utils.generateUniqueKey(item, index);


### PR DESCRIPTION
When switching to a new a recipe from one already displayed, the disabled steps would carry over to the new recipe.