### PR TITLE
Fix en-US language not being loaded

### DIFF
--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -20,25 +20,19 @@ function setI18nLanguage (lang) {
 }
 
 export function loadLanguageAsync(lang) {
-    // If the same language
-  if (i18n.locale === lang) {
-    return Promise.resolve(setI18nLanguage(lang))
-  }
 
-  // If the language was already loaded
-  if (loadedLanguages.includes(lang)) {
-    return Promise.resolve(setI18nLanguage(lang))
+  if ( ! loadedLanguages.includes(lang)) {
+    const messages = import(`./locales/messages/${lang}.json`);
+    const dateTimeFormats = import(`./locales/dateTimeFormats/${lang}.json`);
+    
+    return Promise.all([messages, dateTimeFormats]).then(
+      values  => {
+        i18n.setLocaleMessage(lang, values[0].default)
+        i18n.setDateTimeFormat(lang, values[1].default)
+        loadedLanguages.push(lang)
+        return setI18nLanguage(lang)
+      }
+    )
   }
-
-  const messages = import(`./locales/messages/${lang}.json`);
-  const dateTimeFormats = import(`./locales/dateTimeFormats/${lang}.json`);
-  
-  return Promise.all([messages, dateTimeFormats]).then(
-    values  => {
-      i18n.setLocaleMessage(lang, values[0].default)
-      i18n.setDateTimeFormat(lang, values[1].default)
-      loadedLanguages.push(lang)
-      return setI18nLanguage(lang)
-    }
-  ) 
+  return Promise.resolve(setI18nLanguage(lang))
 }


### PR DESCRIPTION
VueI18n defaults to en-US when no language is specified, which prevented en-US messages from being loaded.