### PR TITLE
Remove unmaintained languages + minor localization tasks

### DIFF
--- a/frontend/src/components/Fallbacks/The404.vue
+++ b/frontend/src/components/Fallbacks/The404.vue
@@ -2,7 +2,7 @@
   <div>
     <v-card-title>
       <slot>
-        <h1 class="mx-auto">{{ $t("404.page-not-found") }}</h1>
+        <h1 class="mx-auto">{{ $t('page.404-page-not-found') }}</h1>
       </slot>
     </v-card-title>
     <div class="d-flex justify-space-around">

--- a/frontend/src/components/UI/SiteLoader.vue
+++ b/frontend/src/components/UI/SiteLoader.vue
@@ -7,14 +7,14 @@
         </v-icon>
         <div v-if="large" class="text-small">
           <slot>
-            {{ small ? "" : "Loading Recipes" }}
+            {{ small ? "" : waitingText }}
           </slot>
         </div>
       </div>
     </v-progress-circular>
     <div v-if="!large" class="text-small">
       <slot>
-        {{ small ? "" : "Loading Recipes" }}
+        {{ small ? "" : waitingText }}
       </slot>
     </div>
   </div>
@@ -60,6 +60,9 @@ export default {
         size: 125,
       };
     },
+    waitingText() {
+      return this.$t("general.loading-recipes");
+    }
   },
 };
 </script>

--- a/frontend/src/locales/messages/en-US.json
+++ b/frontend/src/locales/messages/en-US.json
@@ -203,7 +203,8 @@
     "page-update-failed": "Page update failed",
     "page-updated": "Page updated",
     "pages-update-failed": "Pages update failed",
-    "pages-updated": "Pages updated"
+    "pages-updated": "Pages updated",
+    "404-page-not-found": "404 Page not found"
   },
   "recipe": {
     "add-key": "Add Key",

--- a/frontend/src/locales/messages/en-US.json
+++ b/frontend/src/locales/messages/en-US.json
@@ -36,15 +36,15 @@
   "events": {
     "apprise-url": "Apprise URL",
     "database": "Database",
+    "delete-event": "Delete Event",
     "new-notification-form-description": "Mealie uses the Apprise library to generate notifications. They offer many options for services to use for notifications. Refer to their wiki for a comprehensive guide on how to create the URL for your service. If available, selecting the type of your notification may include extra features.",
+    "new-version": "New version available!",
     "notification": "Notification",
+    "refresh": "Refresh",
     "scheduled": "Scheduled",
     "something-went-wrong": "Something Went Wrong!",
     "subscribed-events": "Subscribed Events",
-    "test-message-sent": "Test Message Sent",
-    "refresh": "Refresh",
-    "new-version": "New version available!",
-    "delete-event": "Delete Event"
+    "test-message-sent": "Test Message Sent"
   },
   "general": {
     "cancel": "Cancel",
@@ -81,10 +81,12 @@
     "json": "JSON",
     "keyword": "Keyword",
     "link-copied": "Link Copied",
+    "loading-recipes": "Loading Recipes",
     "monday": "Monday",
     "name": "Name",
     "new": "New",
     "no": "No",
+    "no-recipe-found": "No Recipe Found",
     "ok": "OK",
     "options": "Options:",
     "print": "Print",
@@ -119,8 +121,7 @@
     "url": "URL",
     "view": "View",
     "wednesday": "Wednesday",
-    "yes": "Yes",
-    "no-recipe-found": "No Recipe Found"
+    "yes": "Yes"
   },
   "group": {
     "are-you-sure-you-want-to-delete-the-group": "Are you sure you want to delete <b>{groupName}<b/>?",
@@ -193,6 +194,7 @@
     "url-form-hint": "Copy and paste a link from your favorite recipe website"
   },
   "page": {
+    "404-page-not-found": "404 Page not found",
     "all-recipes": "All Recipes",
     "home-page": "Home Page",
     "new-page-created": "New page created",
@@ -203,8 +205,7 @@
     "page-update-failed": "Page update failed",
     "page-updated": "Page updated",
     "pages-update-failed": "Pages update failed",
-    "pages-updated": "Pages updated",
-    "404-page-not-found": "404 Page not found"
+    "pages-updated": "Pages updated"
   },
   "recipe": {
     "add-key": "Add Key",
@@ -292,12 +293,12 @@
       "backup-deleted": "Backup deleted",
       "backup-tag": "Backup Tag",
       "create-heading": "Create a Backup",
+      "delete-backup": "Delete Backup",
       "error-creating-backup-see-log-file": "Error Creating Backup. See Log File",
       "full-backup": "Full Backup",
       "import-summary": "Import Summary",
       "partial-backup": "Partial Backup",
-      "unable-to-delete-backup": "Unable to Delete Backup.",
-      "delete-backup": "Delete Backup"
+      "unable-to-delete-backup": "Unable to Delete Backup."
     },
     "backup-and-exports": "Backups",
     "change-password": "Change Password",

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -9,10 +9,8 @@ import es from "vuetify/es5/locale/es";
 import fr from "vuetify/es5/locale/fr";
 import nl from "vuetify/es5/locale/nl";
 import pl from "vuetify/es5/locale/pl";
-import pt from "vuetify/es5/locale/pt";
 import sv from "vuetify/es5/locale/sv";
 import zhHans from "vuetify/es5/locale/zh-Hans";
-import zhHant from "vuetify/es5/locale/zh-Hant";
 
 const vuetify = new Vuetify({
   theme: {
@@ -48,10 +46,8 @@ const vuetify = new Vuetify({
       "fr-FR": fr,
       "nl-NL": nl,
       "pl-PL": pl,
-      "pt-PT": pt,
       "sv-SE": sv,
       "zh-CN": zhHans,
-      "zh-TW": zhHant,
     },
     current: "en-US",
   },

--- a/frontend/src/store/modules/language.js
+++ b/frontend/src/store/modules/language.js
@@ -6,10 +6,6 @@ const state = {
       value: "en-US",
     },
     {
-      name: "Dansk (Danish)",
-      value: "da-DK",
-    },
-    {
       name: "Deutsch (German)",
       value: "de-DE",
     },
@@ -30,20 +26,12 @@ const state = {
       value: "pl-PL",
     },
     {
-      name: "Português (Portuguese)",
-      value: "pt-PT",
-    },
-    {
       name: "Svenska (Swedish)",
       value: "sv-SE",
     },
     {
       name: "简体中文 (Chinese simplified)",
       value: "zh-CN",
-    },
-    {
-      name: "繁體中文 (Chinese traditional)",
-      value: "zh-TW",
     },
   ],
 };


### PR DESCRIPTION
Remove support for Danish, Portuguese and Chinese Traditional, since their current translation state is <20% and translation dynamic is poor to null (https://crowdin.com/project/mealie).

NB: this only prevents users from selecting the language in the UI. Users currently using a now unsupported language will see no difference, since the translations are still shipped with Mealie and the database settings are unchanged.