### PR TITLE
Handle untitled note

### DIFF
--- a/frontend/src/components/Recipe/Parts/Notes.vue
+++ b/frontend/src/components/Recipe/Parts/Notes.vue
@@ -55,7 +55,7 @@ export default {
       return utils.generateUniqueKey(item, index);
     },
     addNote() {
-      this.value.push({ text: "" });
+      this.value.push({ title: "", text: "" });
     },
     removeByIndex(list, index) {
       list.splice(index, 1);

--- a/frontend/src/components/Recipe/RecipePageActionMenu.vue
+++ b/frontend/src/components/Recipe/RecipePageActionMenu.vue
@@ -134,7 +134,6 @@ export default {
           break;
         case SAVE_EVENT:
           this.$emit(SAVE_EVENT);
-          this.$emit("input", false);
           break;
         case JSON_EVENT:
           this.$emit(JSON_EVENT);

--- a/frontend/src/pages/Recipe/ViewRecipe.vue
+++ b/frontend/src/pages/Recipe/ViewRecipe.vue
@@ -233,6 +233,7 @@ export default {
     async saveRecipe() {
       if (this.validateRecipe()) {
         let slug = await api.recipes.update(this.recipeDetails);
+        if(!slug) return;
 
         if (this.fileObject) {
           this.saveImage(true);


### PR DESCRIPTION
 - Leave recipe in edit mode in case of an API error
- Initialize recipe note with empty title

Fixes #586

