### PR TITLE
Hide DB credentials on logs/frontend

### DIFF
--- a/mealie/app.py
+++ b/mealie/app.py
@@ -63,7 +63,20 @@ def system_startup():
     start_scheduler()
     logger.info("-----SYSTEM STARTUP----- \n")
     logger.info("------APP SETTINGS------")
-    logger.info(settings.json(indent=4, exclude={"SECRET", "DEFAULT_PASSWORD", "SFTP_PASSWORD", "SFTP_USERNAME"}))
+    logger.info(
+        settings.json(
+            indent=4,
+            exclude={
+                "SECRET",
+                "DEFAULT_PASSWORD",
+                "SFTP_PASSWORD",
+                "SFTP_USERNAME",
+                "DB_URL",  # replace by DB_URL_PUBLIC for logs
+                "POSTGRES_USER",
+                "POSTGRES_PASSWORD",
+            },
+        )
+    )
     create_general_event("Application Startup", f"Mealie API started on port {settings.API_PORT}")
 
 

--- a/mealie/core/config.py
+++ b/mealie/core/config.py
@@ -133,6 +133,20 @@ class AppSettings(BaseSettings):
             )
         return determine_sqlite_path()
 
+    DB_URL_PUBLIC: str = ""  # hide credentials to show on logs/frontend
+
+    @validator("DB_URL_PUBLIC", pre=True)
+    def public_db_url(cls, v: Optional[str], values: dict[str, Any]) -> str:
+        url = values.get("DB_URL")
+        engine = values.get("DB_ENGINE", "sqlite")
+        if engine == "postgres":
+            user = values.get("POSTGRES_USER")
+            password = values.get("POSTGRES_PASSWORD")
+            return url.replace(user, "*****", 1).replace(password, "*****", 1)
+        else:
+            # sqlite
+            return url
+
     DEFAULT_GROUP: str = "Home"
     DEFAULT_EMAIL: str = "changeme@email.com"
     DEFAULT_PASSWORD: str = "MyPassword"

--- a/mealie/routes/debug_routes.py
+++ b/mealie/routes/debug_routes.py
@@ -25,7 +25,7 @@ async def get_debug_info():
         api_port=settings.API_PORT,
         api_docs=settings.API_DOCS,
         db_type=settings.DB_ENGINE,
-        db_url=settings.DB_URL,
+        db_url=settings.DB_URL_PUBLIC,
         default_group=settings.DEFAULT_GROUP,
     )
 


### PR DESCRIPTION
Credentials is showing when using PostgreSQL, so I'm did some changes.

UI:
![image](https://user-images.githubusercontent.com/12437747/123808386-48006400-d923-11eb-9ce7-682811574978.png)

Logs:
![image](https://user-images.githubusercontent.com/12437747/123808462-58b0da00-d923-11eb-8b72-8a473d50f7bd.png)
