### PR TITLE
Fix logging an error on successful image scrape

### DIFF
--- a/mealie/services/image/image.py
+++ b/mealie/services/image/image.py
@@ -70,6 +70,6 @@ def scrape_image(image_url: str, slug: str) -> Path:
 
         filename.unlink(missing_ok=True)
 
-        return slug
+        return Path(slug)
 
     return None


### PR DESCRIPTION
All my imports were logging:

```
Error Scraping Image: 'str' object has no attribute 'name'
```

scrape_image() is meant to return Path, not a string