### PR TITLE
Also update build for prod

### DIFF
--- a/.github/workflows/dockerbuild.prod.yml
+++ b/.github/workflows/dockerbuild.prod.yml
@@ -45,4 +45,4 @@ jobs:
         run: |
           docker build --push \
             --tag hkotel/mealie:latest \
-            --platform linux/amd64,linux/arm/v7,linux/arm64 .
+            --platform linux/amd64,linux/arm64 .


### PR DESCRIPTION
I saw that the github action failed for the latest build and that you adjusted the build script: 
https://github.com/hay-kot/mealie/commit/fa6743110f1dfd3d5bafb5a73b20b6b68330db7f

But the adjustment is missing in the prod action as well.
So this PR makes the same adjustment to the prod action, so hopefully the action will run without issues and the version is released to docker under the `latest` tag. 