### PR TITLE
reference default login credentials per the documentation

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-# Use root/example as user/password credentials
+# Use changeme@email.com/MyPassword as user/password credentials
 version: "3.1"
 services:
   # Vue Frontend


### PR DESCRIPTION
The default credentials for login listed in the [documentation](https://hay-kot.github.io/mealie/documentation/admin/user-management/) are updated in this docker-compose file.