### PR TITLE
Make Recipe Image Clickable

### DIFF
--- a/frontend/src/pages/Recipe/ViewRecipe.vue
+++ b/frontend/src/pages/Recipe/ViewRecipe.vue
@@ -5,6 +5,7 @@
     </v-card>
     <NoRecipe v-else-if="loadFailed" />
     <v-card v-else-if="!loadFailed" id="myRecipe" class="d-print-none">
+    <a :href="getImage(recipeDetails.slug)">
       <v-img
         :height="hideImage ? '50' : imageHeight"
         @error="hideImage = true"
@@ -19,6 +20,7 @@
           :performTime="recipeDetails.performTime"
         />
       </v-img>
+    </a>
       <RecipePageActionMenu
         :slug="recipeDetails.slug"
         :name="recipeDetails.name"


### PR DESCRIPTION
This makes the recipe image clickable.  This is helpful because some people have scans of their recipes with the instructions within the image.  The UI shrinks and only shows a part of the image.  This allows the user to click the image and then see the full version of the recipe image for printing or reading rather than needing to download and extract a zip of the recipe to get to the image.